### PR TITLE
Fix a few papercuts

### DIFF
--- a/data/net.nokyan.Resources.metainfo.xml.in.in
+++ b/data/net.nokyan.Resources.metainfo.xml.in.in
@@ -27,6 +27,8 @@
   </description>
   <url type="homepage">https://github.com/nokyan/resources</url>
   <url type="bugtracker">https://github.com/nokyan/resources/issues</url>
+  <url type="vcs-browser">https://github.com/nokyan/resources</url>
+  <url type="translate">https://github.com/nokyan/resources/tree/main/po</url>
   <content_rating type="oars-1.1"/>
   <developer_name>nokyan</developer_name>
   <update_contact>nokyan@tuta.io</update_contact>

--- a/data/resources/ui/shortcuts.ui
+++ b/data/resources/ui/shortcuts.ui
@@ -11,6 +11,12 @@
             <property name="title" translatable="yes" context="shortcut window">General</property>
             <child>
               <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Preferences</property>
+                <property name="action-name">app.settings</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes" context="shortcut window">Show Shortcuts</property>
                 <property name="action-name">win.show-help-overlay</property>
               </object>

--- a/src/application.rs
+++ b/src/application.rs
@@ -122,6 +122,7 @@ impl Application {
     // Sets up keyboard shortcuts
     fn setup_accels(&self) {
         self.set_accels_for_action("app.quit", &["<Control>q"]);
+        self.set_accels_for_action("app.settings", &["<Control>comma"]);
         self.set_accels_for_action("app.toggle-search", &["<Control>f", "F3"]);
     }
 

--- a/src/application.rs
+++ b/src/application.rs
@@ -165,6 +165,9 @@ impl Application {
             "https://github.com/nokyan/resources/issues",
         );
 
+        // Translator credits. Replace "translator-credits" with your name/username, and optionally an email or URL. 
+        // One name per line, please do not remove previous names.
+        about.set_translator_credits(&i18n("translator-credits"));
         about.add_credit_section(Some(&i18n("Icon by")), &["Avhiren"]);
 
         about.set_transient_for(Some(&self.main_window()));


### PR DESCRIPTION
### app: Add Preferences shortcut
Add a shortcut to comply GNOME HIG. 
More information: https://developer.gnome.org/hig/reference/keyboard.html

### app: Add Translator Credits support
This string allows translators to put their name in the about dialog.
More information: https://wiki.gnome.org/TranslationProject/DevGuidelines/Add%20translator%20credits

### appdata: Add cvs-browser and translate URL
These URLs are visible on Flathub and GNOME Software.
More information: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-url