### PR TITLE
Release v1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,12 +935,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
@@ -980,7 +974,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1266,12 +1260,12 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "ordered-multimap"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ed8acf08e98e744e5384c8bc63ceb0364e68a6854187221c18df61c4797690e"
+checksum = "a4d6a8c22fc714f0c2373e6091bf6f5e9b37b1bc0b1184874b7e0a4e303d318f"
 dependencies = [
  "dlv-list",
- "hashbrown 0.13.2",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1490,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "process-data"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-std",
@@ -1586,7 +1580,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "resources"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-process",
@@ -1597,7 +1591,7 @@ dependencies = [
  "glob",
  "gtk-macros",
  "gtk4",
- "hashbrown 0.14.2",
+ "hashbrown",
  "libadwaita",
  "log",
  "nix",
@@ -1657,9 +1651,9 @@ dependencies = [
 
 [[package]]
 name = "rust-ini"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e2a3bcec1f113553ef1c88aae6c020a369d03d55b58de9869a0908930385091"
+checksum = "3e0698206bcb8882bf2a9ecb4c1e7785db57ff052297085a6efd4fe42302068a"
 dependencies = [
  "cfg-if",
  "ordered-multimap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resources"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["nokyan <nokyan@tuta.io>"]
 edition = "2021"
 
@@ -39,7 +39,7 @@ plotters-cairo = "0.5.0"
 serde = { version = "1.0.180", features = ["serde_derive"] }
 rmp-serde = "1.1.2"
 async-process = "1.7.0"
-rust-ini = "0.19.0"
+rust-ini = "0.20.0"
 gtk-macros = "0.3.0"
 strum = "0.25.0"
 strum_macros = "0.25.2"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Please do not theme this app](https://stopthemingmy.app/badge.svg)](https://stopthemingmy.app)
 
-Resources is a simple yet powerful monitor for your system resources and processes, written in Rust and using GTK 4 and libadwaita for its GUI. It's capable of displaying usage and details of your CPU, memory, GPUs, network interfaces and block devices. It's also capable of listing and terminating running graphical applications as well as processes.
+Resources is a simple yet powerful monitor for your system resources and processes, written in Rust and using GTK 4 and libadwaita for its GUI. It's capable of displaying usage and details of your CPU, memory, GPUs (AMD and NVIDIA only currently), network interfaces and block devices. It's also capable of listing and terminating running graphical applications as well as processes.
 
 <details>
   <summary><b>Click me for screenshots!</b></summary>
@@ -33,7 +33,21 @@ Other dependencies are handled by `cargo`.
 
 ## Installing
 
-Resources uses Meson as its build system.
+The **offical** and **only supported** way of installing Resources is using Flatpak. Simply use your graphical software manager like GNOME Software or Discover to install Resources from Flathub or type ``flatpak install flathub net.nokyan.Resources`` in your terminal.
+Please keep in mind that you need to have Flathub set up on your device. You can find out how to set up Flathub [here](https://flathub.org/setup).
+
+### Fedora
+
+**Unofficially** packaged in [COPR](https://copr.fedorainfracloud.org/coprs/atim/resources/) for Fedora 39 and newer.
+
+```sh
+dnf copr enable atim/resources
+dnf install resources
+```
+
+## Building
+
+If you prefer to build Resources yourself, you can do so using its build system Meson.
 You can either build and install Resources natively on your system like this:
 
 ```sh
@@ -50,18 +64,11 @@ flatpak-builder --user flatpak_app build-aux/net.nokyan.Resources.Devel.json
 
 If you use [GNOME Builder](https://apps.gnome.org/app/org.gnome.Builder/) or Visual Studio Code with the [Flatpak extension](https://marketplace.visualstudio.com/items?itemName=bilelmoussaoui.flatpak-vscode), Resources can be built and run automatically.
 
-### Fedora
-
-**Unofficially** packaged in [COPR](https://copr.fedorainfracloud.org/coprs/atim/resources/) for Fedora 39 and newer.
-
-```sh
-dnf copr enable atim/resources
-dnf install resources
-```
-
 ## Running
 
-Running Resources is as simple as typing `resources` into a terminal or running it from your application launcher. If you've built Resources using Flatpak, type `flatpak-builder --run flatpak_app build-aux/net.nokyan.Resources.Devel.json resources` into your terminal or use one of the afforementioned IDEs to do that automatically.
+Running Resources is as simple as typing `flatpak run net.nokyan.Resources` into a terminal or running it from your application launcher.
+If you've built Resources natively or installed it from a traditional package manager such as `apt` or `dnf`, or if you've built Resources yourself, typing `resources` in a terminal will start Resources.
+If you've built Resources as a Flatpak, type `flatpak-builder --run flatpak_app build-aux/net.nokyan.Resources.Devel.json resources` into your terminal or use one of the afforementioned IDEs to do that automatically.
 
 ## To-do
 

--- a/data/net.nokyan.Resources.metainfo.xml.in.in
+++ b/data/net.nokyan.Resources.metainfo.xml.in.in
@@ -52,10 +52,15 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.2.0" date="2023-10-31"/>
     <release version="1.1.0" date="2023-10-15"/>
     <release version="1.0.3" date="2023-10-11"/>
     <release version="1.0.2" date="2023-10-10"/>
     <release version="1.0.1" date="2023-10-09"/>
     <release version="1.0.0" date="2023-10-08"/>
   </releases>
+  <custom>
+    <value key="Purism::form_factor">workstation</value>
+    <value key="Purism::form_factor">mobile</value>
+  </custom>
 </component>

--- a/lib/process_data/Cargo.toml
+++ b/lib/process_data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "process-data"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["nokyan <nokyan@tuta.io>"]
 edition = "2021"
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'resources',
   'rust',
-  version: '1.1.0',
+  version: '1.2.0',
   meson_version: '>= 0.59',
 )
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,6 +5,6 @@ option(
     'default',
     'development'
   ],
-  value: 'default',
+  value: 'development',
   description: 'The build profile for Resources. One of "default" or "development".'
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -22,7 +22,7 @@ run_command(
 cargo_options = [ '--manifest-path', meson.project_source_root() / 'Cargo.toml' ]
 cargo_options += [ '--target-dir', meson.project_build_root() / 'src' ]
 
-if get_option('profile') != 'default'
+if get_option('profile') == 'default'
   cargo_options += [ '--release' ]
   rust_target = 'release'
   message('Building in release mode')


### PR DESCRIPTION
This release was supposed to bring support for per-process GPU statistics (and also be released a few days earlier), but that's still in the works (see the `gpu-restructure` branch). Still, Resources 1.2.0 brings a bunch of new features and fixes.

- Fixed: Partial crash when launching Resources on a CPU with lots of threads
- Fixed: On very slim form factors the window content would be cut off to the right
- Fixed: Random crash when trying to perform an action on an app/process
- Fixed: Natively installed LibreOffice was not recognized as an app
- Fixed: Child processes of natively installed Firefox were not properly recognized belonging to the Firefox app
- Fixed: Partial crash when resuming from suspend
- Improvement: Dead processes are now properly cleaned from memory
- Improvement: Resources can now be used on mobile form factors
- New: Resources can now distinguish between "real" drives and virtual drives (such as LVM containers), not showing virtual drives by default (can be toggled)
- New: Resources can now distinguish between "real" network interfaces and virtual network interfaces (such as bridges), not showing virtual network interfaces by default (can be toggled)
- New: Resources can now monitor disk activity per process, this can be enabled in the settings
- New: Individual columns in Applications and Processes views can be toggled on or off in the settings
- New: Shortcut (Ctrl+F or F3) for opening the search bar in Applications and Processes views
- New: Setting for opening the search bar in Applications Processes views immediately after launch
- New: Network speeds can now also be shown in bits per second.
- Languages: Added support for Spanish, Georgian, Dutch, Portuguese (Brazil), Ukrainian