### PR TITLE
utils/network: Support for `virbr` interfaces

### DIFF
--- a/src/utils/network.rs
+++ b/src/utils/network.rs
@@ -122,6 +122,7 @@ impl NetworkInterface {
                 "ib" => InterfaceType::InfiniBand,
                 "sl" => InterfaceType::Slip,
                 "veth" => InterfaceType::VirtualEthernet,
+                "virbr" => InterfaceType::VmBridge,
                 "wg" => InterfaceType::Wireguard,
                 "wl" => InterfaceType::Wlan,
                 "ww" => InterfaceType::Wwan,


### PR DESCRIPTION
I mapped them as VmBridge because there isn't a specific CtBridge (ContainerBridge) enum, if this isn't desirable, feel free to change it.