### PR TITLE
Release 1.2.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "resources"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["nokyan <nokyan@tuta.io>"]
 edition = "2021"
 

--- a/data/net.nokyan.Resources.metainfo.xml.in.in
+++ b/data/net.nokyan.Resources.metainfo.xml.in.in
@@ -52,6 +52,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.2.1" date="2023-11-02"/>
     <release version="1.2.0" date="2023-10-31"/>
     <release version="1.1.0" date="2023-10-15"/>
     <release version="1.0.3" date="2023-10-11"/>

--- a/lib/process_data/Cargo.toml
+++ b/lib/process_data/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "process-data"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["nokyan <nokyan@tuta.io>"]
 edition = "2021"
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'resources',
   'rust',
-  version: '1.2.0',
+  version: '1.2.1',
   meson_version: '>= 0.59',
 )
 


### PR DESCRIPTION
This is just a small bugfix release addressing the following issues:
- Fixed: Loop Devices were not properly recognized as such and were displayed in the sidebar even when 'Show Virtual Drives' was disabled (#84)
- Fixed: VM Bridges were not properly recognized as such and were displayed in the sidebar even when 'Show Virtual Network Interfaces' was disabled (#22)
- Fixed: Resources was still not properly declared as a mobile-friendly app (#31)