### PR TITLE
Plug the memory leak

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1.0.75"
 log = "0.4.20"
 pretty_env_logger = "0.5"
 gettext-rs = { version = "0.7", features = ["gettext-system"] }
-gtk = { version = "0.7.3", features = ["v4_10"], package = "gtk4" }
+gtk = { version = "0.7.3", features = ["v4_8"], package = "gtk4" }
 adw = { version = "0.5.3", features = ["v1_4"], package = "libadwaita" }
 regex = "1.10.2"
 sysconf = "0.3.4"

--- a/data/resources/ui/widgets/application_name_cell.ui
+++ b/data/resources/ui/widgets/application_name_cell.ui
@@ -18,6 +18,7 @@
         <property name="vexpand">1</property>
         <property name="valign">center</property>
         <property name="text-overflow">2</property>
+        <property name="min-chars">12</property>
       </object>
     </child>
   </template>

--- a/data/resources/ui/widgets/process_name_cell.ui
+++ b/data/resources/ui/widgets/process_name_cell.ui
@@ -18,6 +18,7 @@
         <property name="vexpand">1</property>
         <property name="valign">center</property>
         <property name="text-overflow">2</property>
+        <property name="min-chars">12</property>
       </object>
     </child>
   </template>

--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,7 @@ base_id = 'net.nokyan.Resources'
 
 dependency('glib-2.0', version: '>= 2.66')
 dependency('gio-2.0', version: '>= 2.66')
-dependency('gtk4', version: '>= 4.10.0')
+dependency('gtk4', version: '>= 4.8.0')
 dependency('libadwaita-1', version: '>= 1.4.0')
 
 glib_compile_resources = find_program('glib-compile-resources', required: true)

--- a/src/ui/pages/applications/application_entry.rs
+++ b/src/ui/pages/applications/application_entry.rs
@@ -30,7 +30,7 @@ mod imp {
         description: Cell<Option<glib::GString>>,
 
         #[property(get = Self::icon, set = Self::set_icon, type = Icon)]
-        icon: RefCell<Icon>,
+        icon: Cell<Icon>,
 
         #[property(get, set)]
         cpu_usage: Cell<f32>,
@@ -71,7 +71,7 @@ mod imp {
                 name: Cell::new(glib::GString::default()),
                 id: Cell::new(None),
                 description: Cell::new(None),
-                icon: RefCell::new(ThemedIcon::new("generic-process").into()),
+                icon: Cell::new(ThemedIcon::new("generic-process").into()),
                 cpu_usage: Cell::new(0.0),
                 memory_usage: Cell::new(0),
                 read_speed: Cell::new(0.0),
@@ -122,9 +122,7 @@ mod imp {
         }
 
         pub fn icon(&self) -> Icon {
-            let icon = self
-                .icon
-                .replace_with(|_| ThemedIcon::new("generic-process").into());
+            let icon = self.icon.replace(ThemedIcon::new("generic-process").into());
             let result = icon.clone();
             self.icon.set(icon);
             result

--- a/src/ui/pages/applications/mod.rs
+++ b/src/ui/pages/applications/mod.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 use adw::ResponseAppearance;
 use adw::{prelude::*, subclass::prelude::*};
 use gtk::glib::{self, clone, closure, Object, Sender};
-use gtk::{gio, CustomSorter, FilterChange, ListItem, Ordering, SortType, Widget};
+use gtk::{gio, FilterChange, ListItem, NumericSorter, SortType, StringSorter, Widget};
 use gtk_macros::send;
 
 use log::error;
@@ -504,8 +504,7 @@ impl ResApplications {
             .borrow()
             .sorter()
             .and_downcast::<gtk::ColumnViewSorter>()
-            .unwrap()
-            .changed(gtk::SorterChange::Different);
+            .map(|sorter| sorter.changed(gtk::SorterChange::Different));
 
         // -1 because we don't want to count System Processes
         self.set_property(
@@ -627,15 +626,14 @@ impl ResApplications {
             this.add_gestures(&child.parent().and_then(|p| p.parent()).unwrap(), &item);
         }));
 
-        let name_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ApplicationEntry>().unwrap();
-            let item_b = b.downcast_ref::<ApplicationEntry>().unwrap();
-            item_a
-                .name()
-                .to_lowercase()
-                .cmp(&item_b.name().to_lowercase())
-                .into()
-        });
+        let name_col_sorter = StringSorter::builder()
+            .ignore_case(true)
+            .expression(gtk::PropertyExpression::new(
+                ApplicationEntry::static_type(),
+                None::<&gtk::Expression>,
+                "name",
+            ))
+            .build();
 
         name_col.set_sorter(Some(&name_col_sorter));
 
@@ -673,11 +671,14 @@ impl ResApplications {
                 .bind(&row, "text", Widget::NONE);
         });
 
-        let memory_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ApplicationEntry>().unwrap().memory_usage();
-            let item_b = b.downcast_ref::<ApplicationEntry>().unwrap().memory_usage();
-            item_a.cmp(&item_b).into()
-        });
+        let memory_col_sorter = NumericSorter::builder()
+            .sort_order(SortType::Ascending)
+            .expression(gtk::PropertyExpression::new(
+                ApplicationEntry::static_type(),
+                None::<&gtk::Expression>,
+                "memory_usage",
+            ))
+            .build();
 
         memory_col.set_sorter(Some(&memory_col_sorter));
         memory_col.set_visible(SETTINGS.apps_show_memory());
@@ -713,17 +714,14 @@ impl ResApplications {
                 .bind(&row, "text", Widget::NONE);
         });
 
-        let cpu_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ApplicationEntry>().unwrap().cpu_usage();
-            let item_b = b.downcast_ref::<ApplicationEntry>().unwrap().cpu_usage();
-            if item_a > item_b {
-                Ordering::Larger
-            } else if item_a < item_b {
-                Ordering::Smaller
-            } else {
-                Ordering::Equal
-            }
-        });
+        let cpu_col_sorter = NumericSorter::builder()
+            .sort_order(SortType::Ascending)
+            .expression(gtk::PropertyExpression::new(
+                ApplicationEntry::static_type(),
+                None::<&gtk::Expression>,
+                "cpu_usage",
+            ))
+            .build();
 
         cpu_col.set_sorter(Some(&cpu_col_sorter));
         cpu_col.set_visible(SETTINGS.apps_show_cpu());
@@ -765,17 +763,14 @@ impl ResApplications {
                 .bind(&row, "text", Widget::NONE);
         });
 
-        let read_speed_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ApplicationEntry>().unwrap().read_speed();
-            let item_b = b.downcast_ref::<ApplicationEntry>().unwrap().read_speed();
-            if item_a > item_b {
-                Ordering::Larger
-            } else if item_a < item_b {
-                Ordering::Smaller
-            } else {
-                Ordering::Equal
-            }
-        });
+        let read_speed_col_sorter = NumericSorter::builder()
+            .sort_order(SortType::Ascending)
+            .expression(gtk::PropertyExpression::new(
+                ApplicationEntry::static_type(),
+                None::<&gtk::Expression>,
+                "read_speed",
+            ))
+            .build();
 
         read_speed_col.set_sorter(Some(&read_speed_col_sorter));
         read_speed_col.set_visible(SETTINGS.apps_show_drive_read_speed());
@@ -814,11 +809,14 @@ impl ResApplications {
                 .bind(&row, "text", Widget::NONE);
         });
 
-        let read_total_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ApplicationEntry>().unwrap().read_total();
-            let item_b = b.downcast_ref::<ApplicationEntry>().unwrap().read_total();
-            item_a.cmp(&item_b).into()
-        });
+        let read_total_col_sorter = NumericSorter::builder()
+            .sort_order(SortType::Ascending)
+            .expression(gtk::PropertyExpression::new(
+                ApplicationEntry::static_type(),
+                None::<&gtk::Expression>,
+                "read_total",
+            ))
+            .build();
 
         read_total_col.set_sorter(Some(&read_total_col_sorter));
         read_total_col.set_visible(SETTINGS.apps_show_drive_read_total());
@@ -861,17 +859,14 @@ impl ResApplications {
                 .bind(&row, "text", Widget::NONE);
         });
 
-        let write_speed_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ApplicationEntry>().unwrap().write_speed();
-            let item_b = b.downcast_ref::<ApplicationEntry>().unwrap().write_speed();
-            if item_a > item_b {
-                Ordering::Larger
-            } else if item_a < item_b {
-                Ordering::Smaller
-            } else {
-                Ordering::Equal
-            }
-        });
+        let write_speed_col_sorter = NumericSorter::builder()
+            .sort_order(SortType::Ascending)
+            .expression(gtk::PropertyExpression::new(
+                ApplicationEntry::static_type(),
+                None::<&gtk::Expression>,
+                "write_speed",
+            ))
+            .build();
 
         write_speed_col.set_sorter(Some(&write_speed_col_sorter));
         write_speed_col.set_visible(SETTINGS.apps_show_drive_write_speed());
@@ -911,11 +906,14 @@ impl ResApplications {
                 .bind(&row, "text", Widget::NONE);
         });
 
-        let write_total_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ApplicationEntry>().unwrap().write_total();
-            let item_b = b.downcast_ref::<ApplicationEntry>().unwrap().write_total();
-            item_a.cmp(&item_b).into()
-        });
+        let write_total_col_sorter = NumericSorter::builder()
+            .sort_order(SortType::Ascending)
+            .expression(gtk::PropertyExpression::new(
+                ApplicationEntry::static_type(),
+                None::<&gtk::Expression>,
+                "write_total",
+            ))
+            .build();
 
         write_total_col.set_sorter(Some(&write_total_col_sorter));
         write_total_col.set_visible(SETTINGS.apps_show_drive_write_total());
@@ -952,17 +950,14 @@ impl ResApplications {
                 .bind(&row, "text", Widget::NONE);
         });
 
-        let gpu_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ApplicationEntry>().unwrap().gpu_usage();
-            let item_b = b.downcast_ref::<ApplicationEntry>().unwrap().gpu_usage();
-            if item_a > item_b {
-                Ordering::Larger
-            } else if item_a < item_b {
-                Ordering::Smaller
-            } else {
-                Ordering::Equal
-            }
-        });
+        let gpu_col_sorter = NumericSorter::builder()
+            .sort_order(SortType::Ascending)
+            .expression(gtk::PropertyExpression::new(
+                ApplicationEntry::static_type(),
+                None::<&gtk::Expression>,
+                "gpu_usage",
+            ))
+            .build();
 
         gpu_col.set_sorter(Some(&gpu_col_sorter));
         gpu_col.set_visible(SETTINGS.apps_show_gpu());
@@ -1000,17 +995,14 @@ impl ResApplications {
                 .bind(&row, "text", Widget::NONE);
         });
 
-        let encoder_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ApplicationEntry>().unwrap().enc_usage();
-            let item_b = b.downcast_ref::<ApplicationEntry>().unwrap().enc_usage();
-            if item_a > item_b {
-                Ordering::Larger
-            } else if item_a < item_b {
-                Ordering::Smaller
-            } else {
-                Ordering::Equal
-            }
-        });
+        let encoder_col_sorter = NumericSorter::builder()
+            .sort_order(SortType::Ascending)
+            .expression(gtk::PropertyExpression::new(
+                ApplicationEntry::static_type(),
+                None::<&gtk::Expression>,
+                "enc_usage",
+            ))
+            .build();
 
         encoder_col.set_sorter(Some(&encoder_col_sorter));
         encoder_col.set_visible(SETTINGS.apps_show_encoder());
@@ -1048,17 +1040,14 @@ impl ResApplications {
                 .bind(&row, "text", Widget::NONE);
         });
 
-        let decoder_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ApplicationEntry>().unwrap().dec_usage();
-            let item_b = b.downcast_ref::<ApplicationEntry>().unwrap().dec_usage();
-            if item_a > item_b {
-                Ordering::Larger
-            } else if item_a < item_b {
-                Ordering::Smaller
-            } else {
-                Ordering::Equal
-            }
-        });
+        let decoder_col_sorter = NumericSorter::builder()
+            .sort_order(SortType::Ascending)
+            .expression(gtk::PropertyExpression::new(
+                ApplicationEntry::static_type(),
+                None::<&gtk::Expression>,
+                "dec_usage",
+            ))
+            .build();
 
         decoder_col.set_sorter(Some(&decoder_col_sorter));
         decoder_col.set_visible(SETTINGS.apps_show_decoder());
@@ -1093,17 +1082,14 @@ impl ResApplications {
                 .bind(&row, "text", Widget::NONE);
         });
 
-        let gpu_mem_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a
-                .downcast_ref::<ApplicationEntry>()
-                .unwrap()
-                .gpu_mem_usage();
-            let item_b = b
-                .downcast_ref::<ApplicationEntry>()
-                .unwrap()
-                .gpu_mem_usage();
-            item_a.cmp(&item_b).into()
-        });
+        let gpu_mem_col_sorter = NumericSorter::builder()
+            .sort_order(SortType::Ascending)
+            .expression(gtk::PropertyExpression::new(
+                ApplicationEntry::static_type(),
+                None::<&gtk::Expression>,
+                "gpu_mem_usage",
+            ))
+            .build();
 
         gpu_mem_col.set_sorter(Some(&gpu_mem_col_sorter));
         gpu_mem_col.set_visible(SETTINGS.apps_show_gpu_memory());

--- a/src/ui/pages/applications/mod.rs
+++ b/src/ui/pages/applications/mod.rs
@@ -496,9 +496,11 @@ impl ResApplications {
         });
 
         // add the newly started apps to the store
-        new_items
+        let items: Vec<ApplicationEntry> = new_items
             .drain()
-            .for_each(|(_, new_item)| store.append(&ApplicationEntry::new(new_item)));
+            .map(|(_, new_item)| ApplicationEntry::new(new_item))
+            .collect();
+        store.extend_from_slice(&items);
 
         imp.column_view
             .borrow()

--- a/src/ui/pages/applications/mod.rs
+++ b/src/ui/pages/applications/mod.rs
@@ -505,7 +505,6 @@ impl ResApplications {
         imp.column_view
             .borrow()
             .sorter()
-            .and_downcast::<gtk::ColumnViewSorter>()
             .map(|sorter| sorter.changed(gtk::SorterChange::Different));
 
         // -1 because we don't want to count System Processes

--- a/src/ui/pages/processes/mod.rs
+++ b/src/ui/pages/processes/mod.rs
@@ -310,27 +310,8 @@ impl ResProcesses {
 
         imp.popover_menu.set_parent(self);
 
-        let column_view = gtk::ColumnView::new(None::<gtk::SingleSelection>);
-        let store = gio::ListStore::new::<ProcessEntry>();
-        let filter_model = gtk::FilterListModel::new(
-            Some(store.clone()),
-            Some(gtk::CustomFilter::new(
-                clone!(@strong self as this => move |obj| this.search_filter(obj)),
-            )),
-        );
-        let sort_model = gtk::SortListModel::new(Some(filter_model.clone()), column_view.sorter());
-        let selection_model = gtk::SingleSelection::new(Some(sort_model.clone()));
-        column_view.set_model(Some(&selection_model));
-        selection_model.set_can_unselect(true);
-        selection_model.set_autoselect(false);
-
-        *imp.store.borrow_mut() = store;
-        *imp.selection_model.borrow_mut() = selection_model;
-        *imp.sort_model.borrow_mut() = sort_model;
-        *imp.filter_model.borrow_mut() = filter_model;
-
-        imp.processes_scrolled_window.set_child(Some(&column_view));
-        *imp.column_view.borrow_mut() = column_view;
+        *imp.column_view.borrow_mut() = gtk::ColumnView::new(None::<gtk::SingleSelection>);
+        let column_view = imp.column_view.borrow();
 
         self.add_name_column();
         self.add_pid_column();
@@ -345,6 +326,30 @@ impl ResProcesses {
         self.add_gpu_mem_column();
         self.add_encoder_column();
         self.add_decoder_column();
+
+        let store = gio::ListStore::new::<ProcessEntry>();
+
+        let filter_model = gtk::FilterListModel::new(
+            Some(store.clone()),
+            Some(gtk::CustomFilter::new(
+                clone!(@strong self as this => move |obj| this.search_filter(obj)),
+            )),
+        );
+
+        let sort_model = gtk::SortListModel::new(Some(filter_model.clone()), column_view.sorter());
+
+        let selection_model = gtk::SingleSelection::new(Some(sort_model.clone()));
+        selection_model.set_can_unselect(true);
+        selection_model.set_autoselect(false);
+
+        column_view.set_model(Some(&selection_model));
+
+        *imp.store.borrow_mut() = store;
+        *imp.selection_model.borrow_mut() = selection_model;
+        *imp.sort_model.borrow_mut() = sort_model;
+        *imp.filter_model.borrow_mut() = filter_model;
+
+        imp.processes_scrolled_window.set_child(Some(&*column_view));
     }
 
     pub fn setup_signals(&self) {
@@ -471,18 +476,12 @@ impl ResProcesses {
             store.append(&ProcessEntry::new(new_item, &user_name));
         }
 
-        let column_view = imp.column_view.borrow();
-
-        let sorter = column_view
+        imp.column_view
+            .borrow()
             .sorter()
             .and_downcast::<gtk::ColumnViewSorter>()
-            .unwrap();
-
-        let selected_column = sorter.primary_sort_column();
-
-        let selected_order = sorter.primary_sort_order();
-
-        column_view.sort_by_column(selected_column.as_ref(), selected_order);
+            .unwrap()
+            .changed(gtk::SorterChange::Different);
 
         self.set_property(
             "tab_subtitle",

--- a/src/ui/pages/processes/mod.rs
+++ b/src/ui/pages/processes/mod.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 use adw::ResponseAppearance;
 use adw::{prelude::*, subclass::prelude::*};
 use gtk::glib::{self, clone, closure, Object, Sender};
-use gtk::{gio, CustomSorter, FilterChange, ListItem, Ordering, SortType, Widget};
+use gtk::{gio, FilterChange, ListItem, NumericSorter, SortType, StringSorter, Widget};
 use gtk_macros::send;
 
 use log::error;
@@ -480,8 +480,7 @@ impl ResProcesses {
             .borrow()
             .sorter()
             .and_downcast::<gtk::ColumnViewSorter>()
-            .unwrap()
-            .changed(gtk::SorterChange::Different);
+            .map(|sorter| sorter.changed(gtk::SorterChange::Different));
 
         self.set_property(
             "tab_subtitle",
@@ -630,15 +629,14 @@ impl ResProcesses {
             this.add_gestures(&child.parent().and_then(|p| p.parent()).unwrap(), &item);
         }));
 
-        let name_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ProcessEntry>().unwrap();
-            let item_b = b.downcast_ref::<ProcessEntry>().unwrap();
-            item_a
-                .name()
-                .to_lowercase()
-                .cmp(&item_b.name().to_lowercase())
-                .into()
-        });
+        let name_col_sorter = StringSorter::builder()
+            .ignore_case(true)
+            .expression(gtk::PropertyExpression::new(
+                ProcessEntry::static_type(),
+                None::<&gtk::Expression>,
+                "name",
+            ))
+            .build();
 
         name_col.set_sorter(Some(&name_col_sorter));
 
@@ -666,11 +664,14 @@ impl ResProcesses {
                 .bind(&row, "text", Widget::NONE);
         }));
 
-        let pid_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ProcessEntry>().unwrap();
-            let item_b = b.downcast_ref::<ProcessEntry>().unwrap();
-            item_a.pid().cmp(&item_b.pid()).into()
-        });
+        let pid_col_sorter = NumericSorter::builder()
+            .sort_order(SortType::Ascending)
+            .expression(gtk::PropertyExpression::new(
+                ProcessEntry::static_type(),
+                None::<&gtk::Expression>,
+                "pid",
+            ))
+            .build();
 
         pid_col.set_sorter(Some(&pid_col_sorter));
         pid_col.set_visible(SETTINGS.processes_show_id());
@@ -702,11 +703,14 @@ impl ResProcesses {
                 .bind(&row, "text", Widget::NONE);
         });
 
-        let user_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ProcessEntry>().unwrap();
-            let item_b = b.downcast_ref::<ProcessEntry>().unwrap();
-            item_a.user().cmp(&item_b.user()).into()
-        });
+        let user_col_sorter = StringSorter::builder()
+            .ignore_case(true)
+            .expression(gtk::PropertyExpression::new(
+                ProcessEntry::static_type(),
+                None::<&gtk::Expression>,
+                "user",
+            ))
+            .build();
 
         user_col.set_sorter(Some(&user_col_sorter));
         user_col.set_visible(SETTINGS.processes_show_user());
@@ -742,11 +746,14 @@ impl ResProcesses {
                 .bind(&row, "text", Widget::NONE);
         });
 
-        let memory_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ProcessEntry>().unwrap().memory_usage();
-            let item_b = b.downcast_ref::<ProcessEntry>().unwrap().memory_usage();
-            item_a.cmp(&item_b).into()
-        });
+        let memory_col_sorter = NumericSorter::builder()
+            .sort_order(SortType::Ascending)
+            .expression(gtk::PropertyExpression::new(
+                ProcessEntry::static_type(),
+                None::<&gtk::Expression>,
+                "memory_usage",
+            ))
+            .build();
 
         memory_col.set_sorter(Some(&memory_col_sorter));
         memory_col.set_visible(SETTINGS.processes_show_memory());
@@ -786,17 +793,14 @@ impl ResProcesses {
                 .bind(&row, "text", Widget::NONE);
         });
 
-        let cpu_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ProcessEntry>().unwrap().cpu_usage();
-            let item_b = b.downcast_ref::<ProcessEntry>().unwrap().cpu_usage();
-            if item_a > item_b {
-                Ordering::Larger
-            } else if item_a < item_b {
-                Ordering::Smaller
-            } else {
-                Ordering::Equal
-            }
-        });
+        let cpu_col_sorter = NumericSorter::builder()
+            .sort_order(SortType::Ascending)
+            .expression(gtk::PropertyExpression::new(
+                ProcessEntry::static_type(),
+                None::<&gtk::Expression>,
+                "cpu_usage",
+            ))
+            .build();
 
         cpu_col.set_sorter(Some(&cpu_col_sorter));
         cpu_col.set_visible(SETTINGS.processes_show_cpu());
@@ -838,17 +842,14 @@ impl ResProcesses {
                 .bind(&row, "text", Widget::NONE);
         });
 
-        let read_speed_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ProcessEntry>().unwrap().read_speed();
-            let item_b = b.downcast_ref::<ProcessEntry>().unwrap().read_speed();
-            if item_a > item_b {
-                Ordering::Larger
-            } else if item_a < item_b {
-                Ordering::Smaller
-            } else {
-                Ordering::Equal
-            }
-        });
+        let read_speed_col_sorter = NumericSorter::builder()
+            .sort_order(SortType::Ascending)
+            .expression(gtk::PropertyExpression::new(
+                ProcessEntry::static_type(),
+                None::<&gtk::Expression>,
+                "read_speed",
+            ))
+            .build();
 
         read_speed_col.set_sorter(Some(&read_speed_col_sorter));
         read_speed_col.set_visible(SETTINGS.processes_show_drive_read_speed());
@@ -892,11 +893,14 @@ impl ResProcesses {
                 .bind(&row, "text", Widget::NONE);
         });
 
-        let read_total_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ProcessEntry>().unwrap().read_total();
-            let item_b = b.downcast_ref::<ProcessEntry>().unwrap().read_total();
-            item_a.cmp(&item_b).into()
-        });
+        let read_total_col_sorter = NumericSorter::builder()
+            .sort_order(SortType::Ascending)
+            .expression(gtk::PropertyExpression::new(
+                ProcessEntry::static_type(),
+                None::<&gtk::Expression>,
+                "read_total",
+            ))
+            .build();
 
         read_total_col.set_sorter(Some(&read_total_col_sorter));
         read_total_col.set_visible(SETTINGS.processes_show_drive_read_total());
@@ -940,17 +944,14 @@ impl ResProcesses {
                 .bind(&row, "text", Widget::NONE);
         });
 
-        let write_speed_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ProcessEntry>().unwrap().write_speed();
-            let item_b = b.downcast_ref::<ProcessEntry>().unwrap().write_speed();
-            if item_a > item_b {
-                Ordering::Larger
-            } else if item_a < item_b {
-                Ordering::Smaller
-            } else {
-                Ordering::Equal
-            }
-        });
+        let write_speed_col_sorter = NumericSorter::builder()
+            .sort_order(SortType::Ascending)
+            .expression(gtk::PropertyExpression::new(
+                ProcessEntry::static_type(),
+                None::<&gtk::Expression>,
+                "write_speed",
+            ))
+            .build();
 
         write_speed_col.set_sorter(Some(&write_speed_col_sorter));
         write_speed_col.set_visible(SETTINGS.processes_show_drive_write_speed());
@@ -994,11 +995,14 @@ impl ResProcesses {
                 .bind(&row, "text", Widget::NONE);
         });
 
-        let write_total_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ProcessEntry>().unwrap().write_total();
-            let item_b = b.downcast_ref::<ProcessEntry>().unwrap().write_total();
-            item_a.cmp(&item_b).into()
-        });
+        let write_total_col_sorter = NumericSorter::builder()
+            .sort_order(SortType::Ascending)
+            .expression(gtk::PropertyExpression::new(
+                ProcessEntry::static_type(),
+                None::<&gtk::Expression>,
+                "write_total",
+            ))
+            .build();
 
         write_total_col.set_sorter(Some(&write_total_col_sorter));
         write_total_col.set_visible(SETTINGS.processes_show_drive_write_total());
@@ -1035,17 +1039,14 @@ impl ResProcesses {
                 .bind(&row, "text", Widget::NONE);
         });
 
-        let gpu_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ProcessEntry>().unwrap().gpu_usage();
-            let item_b = b.downcast_ref::<ProcessEntry>().unwrap().gpu_usage();
-            if item_a > item_b {
-                Ordering::Larger
-            } else if item_a < item_b {
-                Ordering::Smaller
-            } else {
-                Ordering::Equal
-            }
-        });
+        let gpu_col_sorter = NumericSorter::builder()
+            .sort_order(SortType::Ascending)
+            .expression(gtk::PropertyExpression::new(
+                ProcessEntry::static_type(),
+                None::<&gtk::Expression>,
+                "gpu_usage",
+            ))
+            .build();
 
         gpu_col.set_sorter(Some(&gpu_col_sorter));
         gpu_col.set_visible(SETTINGS.processes_show_gpu());
@@ -1083,17 +1084,14 @@ impl ResProcesses {
                 .bind(&row, "text", Widget::NONE);
         });
 
-        let encoder_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ProcessEntry>().unwrap().enc_usage();
-            let item_b = b.downcast_ref::<ProcessEntry>().unwrap().enc_usage();
-            if item_a > item_b {
-                Ordering::Larger
-            } else if item_a < item_b {
-                Ordering::Smaller
-            } else {
-                Ordering::Equal
-            }
-        });
+        let encoder_col_sorter = NumericSorter::builder()
+            .sort_order(SortType::Ascending)
+            .expression(gtk::PropertyExpression::new(
+                ProcessEntry::static_type(),
+                None::<&gtk::Expression>,
+                "enc_usage",
+            ))
+            .build();
 
         encoder_col.set_sorter(Some(&encoder_col_sorter));
         encoder_col.set_visible(SETTINGS.processes_show_encoder());
@@ -1131,17 +1129,14 @@ impl ResProcesses {
                 .bind(&row, "text", Widget::NONE);
         });
 
-        let decoder_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ProcessEntry>().unwrap().dec_usage();
-            let item_b = b.downcast_ref::<ProcessEntry>().unwrap().dec_usage();
-            if item_a > item_b {
-                Ordering::Larger
-            } else if item_a < item_b {
-                Ordering::Smaller
-            } else {
-                Ordering::Equal
-            }
-        });
+        let decoder_col_sorter = NumericSorter::builder()
+            .sort_order(SortType::Ascending)
+            .expression(gtk::PropertyExpression::new(
+                ProcessEntry::static_type(),
+                None::<&gtk::Expression>,
+                "dec_usage",
+            ))
+            .build();
 
         decoder_col.set_sorter(Some(&decoder_col_sorter));
         decoder_col.set_visible(SETTINGS.processes_show_decoder());
@@ -1178,11 +1173,14 @@ impl ResProcesses {
                 .bind(&row, "text", Widget::NONE);
         });
 
-        let gpu_mem_col_sorter = CustomSorter::new(move |a, b| {
-            let item_a = a.downcast_ref::<ProcessEntry>().unwrap().gpu_mem_usage();
-            let item_b = b.downcast_ref::<ProcessEntry>().unwrap().gpu_mem_usage();
-            item_a.cmp(&item_b).into()
-        });
+        let gpu_mem_col_sorter = NumericSorter::builder()
+            .sort_order(SortType::Ascending)
+            .expression(gtk::PropertyExpression::new(
+                ProcessEntry::static_type(),
+                None::<&gtk::Expression>,
+                "gpu_mem_usage",
+            ))
+            .build();
 
         gpu_mem_col.set_sorter(Some(&gpu_mem_col_sorter));
         gpu_mem_col.set_visible(SETTINGS.processes_show_gpu_memory());

--- a/src/ui/pages/processes/mod.rs
+++ b/src/ui/pages/processes/mod.rs
@@ -6,7 +6,7 @@ use std::collections::HashSet;
 use adw::ResponseAppearance;
 use adw::{prelude::*, subclass::prelude::*};
 use gtk::glib::{self, clone, closure, Object, Sender};
-use gtk::{gio, FilterChange, ListItem, NumericSorter, SortType, StringSorter, Widget};
+use gtk::{gio, FilterChange, NumericSorter, SortType, StringSorter, Widget};
 use gtk_macros::send;
 
 use log::error;
@@ -563,32 +563,6 @@ impl ResProcesses {
         .to_string()
     }
 
-    fn add_gestures(&self, widget: &impl IsA<Widget>, item: &ListItem) {
-        let secondary_click = gtk::GestureClick::new();
-        secondary_click.set_button(3);
-        secondary_click.connect_released(
-            clone!(@strong self as this, @strong item as this_item, @strong widget as this_widget => move |_, _, x, y| {
-                if let Some(process_entry) = this_item.item().and_downcast_ref::<ProcessEntry>() {
-                    let imp = this.imp();
-                    let popover_menu = &imp.popover_menu;
-
-                    *imp.popped_over_process.borrow_mut() = Some(process_entry.clone());
-
-                    let position = this_widget.compute_point(&this, &gtk::graphene::Point::new(x as _, y as _)).unwrap();
-                    popover_menu.set_pointing_to(Some(&gtk::gdk::Rectangle::new(
-                        position.x().round() as i32,
-                        position.y().round() as i32,
-                        1,
-                        1,
-                    )));
-                    popover_menu.popup();
-                }
-            }),
-        );
-
-        widget.add_controller(secondary_click);
-    }
-
     fn add_name_column(&self) {
         let imp = self.imp();
 
@@ -620,18 +594,6 @@ impl ResProcesses {
                 .chain_property::<ProcessEntry>("commandline")
                 .bind(&row, "tooltip", Widget::NONE);
         });
-
-        name_col_factory.connect_bind(clone!(@strong self as this => move |_, item| {
-            let item = item.downcast_ref::<gtk::ListItem>().unwrap();
-
-            let child = item
-                .child()
-                .unwrap()
-                .downcast::<ResProcessNameCell>()
-                .unwrap();
-
-            this.add_gestures(&child.parent().and_then(|p| p.parent()).unwrap(), &item);
-        }));
 
         let name_col_sorter = StringSorter::builder()
             .ignore_case(true)

--- a/src/ui/pages/processes/mod.rs
+++ b/src/ui/pages/processes/mod.rs
@@ -471,10 +471,14 @@ impl ResProcesses {
         });
 
         // add the newly started process to the store
-        for (_, new_item) in new_items.drain() {
-            let user_name = self.get_user_name_by_uid(new_item.uid);
-            store.append(&ProcessEntry::new(new_item, &user_name));
-        }
+        let items: Vec<ProcessEntry> = new_items
+            .drain()
+            .map(|(_, new_item)| {
+                let user_name = self.get_user_name_by_uid(new_item.uid);
+                ProcessEntry::new(new_item, &user_name)
+            })
+            .collect();
+        store.extend_from_slice(&items);
 
         imp.column_view
             .borrow()

--- a/src/ui/pages/processes/mod.rs
+++ b/src/ui/pages/processes/mod.rs
@@ -483,7 +483,6 @@ impl ResProcesses {
         imp.column_view
             .borrow()
             .sorter()
-            .and_downcast::<gtk::ColumnViewSorter>()
             .map(|sorter| sorter.changed(gtk::SorterChange::Different));
 
         self.set_property(

--- a/src/ui/pages/processes/process_entry.rs
+++ b/src/ui/pages/processes/process_entry.rs
@@ -30,7 +30,7 @@ mod imp {
         user: Cell<glib::GString>,
 
         #[property(get = Self::icon, set = Self::set_icon, type = Icon)]
-        icon: RefCell<Icon>,
+        icon: Cell<Icon>,
 
         #[property(get, set)]
         pid: Cell<i32>,
@@ -74,7 +74,7 @@ mod imp {
                 name: Cell::new(glib::GString::default()),
                 commandline: Cell::new(glib::GString::default()),
                 user: Cell::new(glib::GString::default()),
-                icon: RefCell::new(ThemedIcon::new("generic-process").into()),
+                icon: Cell::new(ThemedIcon::new("generic-process").into()),
                 pid: Cell::new(0),
                 cpu_usage: Cell::new(0.0),
                 memory_usage: Cell::new(0),
@@ -126,9 +126,7 @@ mod imp {
         }
 
         pub fn icon(&self) -> Icon {
-            let icon = self
-                .icon
-                .replace_with(|_| ThemedIcon::new("generic-process").into());
+            let icon = self.icon.replace(ThemedIcon::new("generic-process").into());
             let result = icon.clone();
             self.icon.set(icon);
             result

--- a/src/utils/process.rs
+++ b/src/utils/process.rs
@@ -11,10 +11,7 @@ use std::{
 };
 use strum_macros::Display;
 
-use gtk::{
-    gio::{Icon, ThemedIcon},
-    glib::GString,
-};
+use gtk::gio::{Icon, ThemedIcon};
 
 use crate::config;
 
@@ -86,7 +83,7 @@ pub struct ProcessItem {
     pub cpu_time_ratio: f32,
     pub commandline: String,
     pub containerization: Containerization,
-    pub running_since: GString,
+    pub starttime: f64,
     pub cgroup: Option<String>,
     pub read_speed: Option<f64>,
     pub read_total: Option<u64>,
@@ -409,8 +406,8 @@ impl Process {
     }
 
     #[must_use]
-    pub fn starttime(&self) -> u64 {
-        self.data.starttime / *TICK_RATE as u64
+    pub fn starttime(&self) -> f64 {
+        self.data.starttime as f64 / *TICK_RATE as f64
     }
 
     pub fn sanitize_cmdline<S: AsRef<str>>(cmdline: S) -> Option<String> {


### PR DESCRIPTION
Resources has been suffering from a nasty memory leak for a while now, right now we've at least located where it happens.

It happens during resorting the process and application list after a refresh, especially when many items have changed their position in the list (which happens e. g. when sorting after CPU usage rather than memory usage).
In commit `8d69995`, the culprit lines are at src/ui/pages/processes/mod.rs:484 and src/ui/pages/applications/mod.rs:508.

Unfortunately, I don't know how to fix it yet, I hope I'll be able to fix it with release 1.3.

Update #‎​1 (2023-12-21): I may have fixed the original memory leak on accident before but introduced another one with right-click context menus. I've removed them again for now and during my testing, this fixed it and memory usage is under control