### PR TITLE
Mini graphs in the sidebar

### DIFF
--- a/data/net.nokyan.Resources.gschema.xml.in
+++ b/data/net.nokyan.Resources.gschema.xml.in
@@ -41,6 +41,10 @@
       <default>false</default>
       <summary>Show usage details in the sidebar</summary>
     </key>
+    <key name="sidebar-meter-type" type="s">
+      <default>"Progress Bar"</default>
+      <summary>Sidebar Meter Type</summary>
+    </key>
     <key name="network-bits" type="b">
       <default>false</default>
       <summary>Display network speeds in bits per second</summary>

--- a/data/resources/ui/dialogs/settings_dialog.ui
+++ b/data/resources/ui/dialogs/settings_dialog.ui
@@ -93,6 +93,19 @@
                 <property name="title" translatable="yes">Show Usage Details in Sidebar</property>
               </object>
             </child>
+            <child>
+              <object class="AdwComboRow" id="sidebar_meter_type_row">
+                <property name="title" translatable="yes">Sidebar Meter Type</property>
+                <property name="model">
+                  <object class="GtkStringList">
+                    <items>
+                      <item translatable="yes">Progress Bar</item>
+                      <item translatable="yes">Graph</item>
+                    </items>
+                  </object>
+                </property>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/data/resources/ui/widgets/stack_sidebar_item.ui
+++ b/data/resources/ui/widgets/stack_sidebar_item.ui
@@ -47,6 +47,11 @@
             </style>
           </object>
         </child>
+        <child>
+          <object class="ResGraph" id="graph">
+            <property name="height-request">80</property>
+          </object>
+        </child>
       </object>
     </property>
   </template>

--- a/src/ui/dialogs/settings_dialog.rs
+++ b/src/ui/dialogs/settings_dialog.rs
@@ -3,7 +3,7 @@ use gtk::glib;
 
 use crate::{
     config::PROFILE,
-    utils::settings::{Base, RefreshSpeed, TemperatureUnit, SETTINGS},
+    utils::settings::{Base, RefreshSpeed, SidebarMeterType, TemperatureUnit, SETTINGS},
 };
 
 mod imp {
@@ -32,6 +32,8 @@ mod imp {
         pub show_search_on_start_row: TemplateChild<adw::SwitchRow>,
         #[template_child]
         pub sidebar_details_row: TemplateChild<adw::SwitchRow>,
+        #[template_child]
+        pub sidebar_meter_type_row: TemplateChild<adw::ComboRow>,
 
         #[template_child]
         pub apps_show_memory_row: TemplateChild<adw::SwitchRow>,
@@ -153,6 +155,8 @@ impl ResSettingsDialog {
             .set_value(SETTINGS.graph_data_points() as f64);
         imp.sidebar_details_row
             .set_active(SETTINGS.sidebar_details());
+        imp.sidebar_meter_type_row
+            .set_selected((SETTINGS.sidebar_meter_type() as u8) as u32);
         imp.show_search_on_start_row
             .set_active(SETTINGS.show_search_on_start());
 
@@ -248,6 +252,13 @@ impl ResSettingsDialog {
         imp.sidebar_details_row.connect_active_notify(|switch_row| {
             let _ = SETTINGS.set_sidebar_details(switch_row.is_active());
         });
+
+        imp.sidebar_meter_type_row
+            .connect_selected_item_notify(|combo_row| {
+                if let Some(t) = SidebarMeterType::from_repr(combo_row.selected() as u8) {
+                    let _ = SETTINGS.set_sidebar_meter_type(t);
+                }
+            });
 
         imp.show_search_on_start_row
             .connect_active_notify(|switch_row| {

--- a/src/ui/pages/cpu.rs
+++ b/src/ui/pages/cpu.rs
@@ -62,6 +62,9 @@ mod imp {
         uses_progress_bar: Cell<bool>,
 
         #[property(get)]
+        main_graph_color: glib::Bytes,
+
+        #[property(get)]
         icon: RefCell<Icon>,
 
         #[property(get, set)]
@@ -112,6 +115,7 @@ mod imp {
                 temperature: Default::default(),
                 thread_graphs: Default::default(),
                 uses_progress_bar: Cell::new(true),
+                main_graph_color: glib::Bytes::from_static(&super::ResCPU::MAIN_GRAPH_COLOR),
                 icon: RefCell::new(ThemedIcon::new("processor-symbolic").into()),
                 usage: Default::default(),
                 tab_name: Cell::new(glib::GString::from(i18n("Processor"))),
@@ -173,6 +177,8 @@ glib::wrapper! {
 }
 
 impl ResCPU {
+    const MAIN_GRAPH_COLOR: [u8; 3] = [28, 113, 216];
+
     pub fn new() -> Self {
         glib::Object::new::<Self>()
     }
@@ -198,7 +204,11 @@ impl ResCPU {
 
         imp.total_cpu.set_title_label(&i18n("CPU"));
         imp.total_cpu.set_subtitle(&i18n("N/A"));
-        imp.total_cpu.graph().set_graph_color(28, 113, 216);
+        imp.total_cpu.graph().set_graph_color(
+            Self::MAIN_GRAPH_COLOR[0],
+            Self::MAIN_GRAPH_COLOR[1],
+            Self::MAIN_GRAPH_COLOR[2],
+        );
 
         // if our CPU happens to only have one thread, showing a single thread box with the exact
         // same fraction as the progress bar for total CPU usage would be silly, so only do

--- a/src/ui/pages/drive.rs
+++ b/src/ui/pages/drive.rs
@@ -51,6 +51,9 @@ mod imp {
         #[property(get)]
         uses_progress_bar: Cell<bool>,
 
+        #[property(get)]
+        main_graph_color: glib::Bytes,
+
         #[property(get = Self::icon, set = Self::set_icon, type = Icon)]
         icon: RefCell<Icon>,
 
@@ -111,6 +114,7 @@ mod imp {
                 writable: Default::default(),
                 removable: Default::default(),
                 uses_progress_bar: Cell::new(true),
+                main_graph_color: glib::Bytes::from_static(&super::ResDrive::MAIN_GRAPH_COLOR),
                 icon: RefCell::new(Drive::default_icon()),
                 usage: Default::default(),
                 tab_name: Cell::new(glib::GString::from(i18n("Drive"))),
@@ -176,6 +180,8 @@ glib::wrapper! {
 }
 
 impl ResDrive {
+    const MAIN_GRAPH_COLOR: [u8; 3] = [229, 165, 10];
+
     pub fn new() -> Self {
         glib::Object::new::<Self>()
     }
@@ -192,7 +198,11 @@ impl ResDrive {
         imp.set_tab_name(&drive.display_name(drive_data.capacity as f64));
 
         imp.total_usage.set_title_label(&i18n("Total Usage"));
-        imp.total_usage.graph().set_graph_color(229, 165, 10);
+        imp.total_usage.graph().set_graph_color(
+            Self::MAIN_GRAPH_COLOR[0],
+            Self::MAIN_GRAPH_COLOR[1],
+            Self::MAIN_GRAPH_COLOR[2],
+        );
 
         imp.drive_type.set_subtitle(&drive.drive_type.to_string());
 

--- a/src/ui/pages/gpu.rs
+++ b/src/ui/pages/gpu.rs
@@ -60,6 +60,9 @@ mod imp {
         uses_progress_bar: Cell<bool>,
 
         #[property(get)]
+        main_graph_color: glib::Bytes,
+
+        #[property(get)]
         icon: RefCell<Icon>,
 
         #[property(get, set)]
@@ -114,6 +117,7 @@ mod imp {
                 max_power_cap: Default::default(),
                 number: Default::default(),
                 uses_progress_bar: Cell::new(true),
+                main_graph_color: glib::Bytes::from_static(&super::ResGPU::MAIN_GRAPH_COLOR),
                 icon: RefCell::new(ThemedIcon::new("gpu-symbolic").into()),
                 usage: Default::default(),
                 tab_name: Cell::new(glib::GString::from(i18n("GPU"))),
@@ -172,6 +176,8 @@ glib::wrapper! {
 }
 
 impl ResGPU {
+    const MAIN_GRAPH_COLOR: [u8; 3] = [230, 97, 0];
+
     pub fn new() -> Self {
         glib::Object::new::<Self>()
     }
@@ -186,7 +192,11 @@ impl ResGPU {
         let imp = self.imp();
 
         imp.gpu_usage.set_title_label(&i18n("GPU Usage"));
-        imp.gpu_usage.graph().set_graph_color(230, 97, 0);
+        imp.gpu_usage.graph().set_graph_color(
+            Self::MAIN_GRAPH_COLOR[0],
+            Self::MAIN_GRAPH_COLOR[1],
+            Self::MAIN_GRAPH_COLOR[2],
+        );
 
         imp.encode_decode_combined_usage
             .set_title_label(&i18n("Video Encoder/Decoder Usage"));

--- a/src/ui/pages/memory.rs
+++ b/src/ui/pages/memory.rs
@@ -47,6 +47,9 @@ mod imp {
         uses_progress_bar: Cell<bool>,
 
         #[property(get)]
+        main_graph_color: glib::Bytes,
+
+        #[property(get)]
         icon: RefCell<Icon>,
 
         #[property(get, set)]
@@ -92,6 +95,7 @@ mod imp {
                 memory_type: Default::default(),
                 type_detail: Default::default(),
                 uses_progress_bar: Cell::new(true),
+                main_graph_color: glib::Bytes::from_static(&super::ResMemory::MAIN_GRAPH_COLOR),
                 icon: RefCell::new(ThemedIcon::new("memory-symbolic").into()),
                 usage: Default::default(),
                 tab_name: Cell::new(glib::GString::from(i18n("Memory"))),
@@ -150,6 +154,8 @@ glib::wrapper! {
 }
 
 impl ResMemory {
+    const MAIN_GRAPH_COLOR: [u8; 3] = [129, 61, 156];
+
     pub fn new() -> Self {
         glib::Object::new::<Self>()
     }
@@ -163,8 +169,11 @@ impl ResMemory {
         let imp = self.imp();
 
         imp.memory.set_title_label(&i18n("Memory"));
-        imp.memory.graph().set_graph_color(129, 61, 156);
-
+        imp.memory.graph().set_graph_color(
+            Self::MAIN_GRAPH_COLOR[0],
+            Self::MAIN_GRAPH_COLOR[1],
+            Self::MAIN_GRAPH_COLOR[2],
+        );
         imp.swap.set_title_label(&i18n("Swap"));
         imp.swap.graph().set_graph_color(46, 194, 126);
 

--- a/src/ui/pages/network.rs
+++ b/src/ui/pages/network.rs
@@ -50,6 +50,9 @@ mod imp {
         #[property(get)]
         uses_progress_bar: Cell<bool>,
 
+        #[property(get)]
+        main_graph_color: glib::Bytes,
+
         #[property(get = Self::icon, set = Self::set_icon, type = Icon)]
         icon: RefCell<Icon>,
 
@@ -110,6 +113,7 @@ mod imp {
                 interface: Default::default(),
                 hw_address: Default::default(),
                 uses_progress_bar: Cell::new(true),
+                main_graph_color: glib::Bytes::from_static(&super::ResNetwork::MAIN_GRAPH_COLOR),
                 icon: RefCell::new(ThemedIcon::new("unknown-network-type-symbolic").into()),
                 usage: Default::default(),
                 tab_name: Cell::new(glib::GString::from(i18n("Network Interface"))),
@@ -176,6 +180,12 @@ glib::wrapper! {
 }
 
 impl ResNetwork {
+    // TODO: this is the color for receiving, but it is also used in sidebar,
+    // which graphs the sum of send+recv.
+    // This does not make much sense, but we probably can't do something
+    // like separate send/receive lines without some refactoring to ResGraph.
+    const MAIN_GRAPH_COLOR: [u8; 3] = [52, 170, 175];
+
     pub fn new() -> Self {
         glib::Object::new::<Self>()
     }
@@ -193,7 +203,11 @@ impl ResNetwork {
         imp.set_tab_name(&i18n(&network_interface.interface_type.to_string()));
 
         imp.receiving.set_title_label(&i18n("Receiving"));
-        imp.receiving.graph().set_graph_color(52, 170, 175);
+        imp.receiving.graph().set_graph_color(
+            Self::MAIN_GRAPH_COLOR[0],
+            Self::MAIN_GRAPH_COLOR[1],
+            Self::MAIN_GRAPH_COLOR[2],
+        );
         imp.receiving.graph().set_locked_max_y(None);
 
         imp.sending.set_title_label(&i18n("Sending"));

--- a/src/ui/widgets/stack_sidebar.rs
+++ b/src/ui/widgets/stack_sidebar.rs
@@ -3,7 +3,7 @@ use std::rc::Rc;
 use adw::{prelude::*, subclass::prelude::*};
 use gtk::glib::{self, clone};
 
-use crate::utils::settings::SETTINGS;
+use crate::utils::settings::{SidebarMeterType, SETTINGS};
 
 use super::stack_sidebar_item::ResStackSidebarItem;
 
@@ -143,9 +143,22 @@ impl ResStackSidebar {
                 }),
             );
 
+            // TODO: generalize to "uses_meter"?
             if !child.property::<bool>("uses_progress_bar") {
                 sidebar_item.set_progress_bar_visible(false);
+                sidebar_item.set_graph_visible(false);
             } else {
+                sidebar_item.set_progress_bar_visible(
+                    SETTINGS.sidebar_meter_type() == SidebarMeterType::ProgressBar,
+                );
+                sidebar_item
+                    .set_graph_visible(SETTINGS.sidebar_meter_type() == SidebarMeterType::Graph);
+                SETTINGS.connect_sidebar_meter_type(
+                    clone!(@strong sidebar_item as item => move |sidebar_meter_type| {
+                        item.set_progress_bar_visible(sidebar_meter_type == SidebarMeterType::ProgressBar);
+                        item.set_graph_visible(sidebar_meter_type == SidebarMeterType::Graph);
+                    }),
+                );
                 child
                     .bind_property("usage", &sidebar_item, "usage")
                     .sync_create()

--- a/src/ui/widgets/stack_sidebar.rs
+++ b/src/ui/widgets/stack_sidebar.rs
@@ -148,6 +148,11 @@ impl ResStackSidebar {
                 sidebar_item.set_progress_bar_visible(false);
                 sidebar_item.set_graph_visible(false);
             } else {
+                if child.has_property("main_graph_color", Some(glib::Bytes::static_type())) {
+                    let b = child.property::<glib::Bytes>("main_graph_color");
+                    sidebar_item.set_graph_color(b[0], b[1], b[2]);
+                }
+
                 sidebar_item.set_progress_bar_visible(
                     SETTINGS.sidebar_meter_type() == SidebarMeterType::ProgressBar,
                 );

--- a/src/ui/widgets/stack_sidebar_item.rs
+++ b/src/ui/widgets/stack_sidebar_item.rs
@@ -94,9 +94,6 @@ mod imp {
         pub fn set_usage(&self, usage: f64) {
             self.usage.set(usage);
             self.progress_bar.set_fraction(usage);
-            // TODO: find a better place for this
-            // TODO: make this equal to the corresponding page's main graph color
-            self.graph.set_graph_color(28, 113, 216);
             self.graph.push_data_point(usage);
         }
     }
@@ -177,6 +174,10 @@ impl ResStackSidebarItem {
 
     pub fn set_graph_visible(&self, visible: bool) {
         self.imp().graph.set_visible(visible);
+    }
+
+    pub fn set_graph_color(&self, r: u8, g: u8, b: u8) {
+        self.imp().graph.set_graph_color(r, g, b);
     }
 
     pub fn set_subtitle_visible(&self, visible: bool) {

--- a/src/ui/widgets/stack_sidebar_item.rs
+++ b/src/ui/widgets/stack_sidebar_item.rs
@@ -27,6 +27,8 @@ mod imp {
         pub subtitle_label: TemplateChild<gtk::Label>,
         #[template_child]
         pub progress_bar: TemplateChild<gtk::ProgressBar>,
+        #[template_child]
+        pub graph: TemplateChild<super::super::graph::ResGraph>,
 
         #[property(get = Self::name, set = Self::set_name, type = glib::GString)]
         name: Cell<glib::GString>,
@@ -92,6 +94,10 @@ mod imp {
         pub fn set_usage(&self, usage: f64) {
             self.usage.set(usage);
             self.progress_bar.set_fraction(usage);
+            // TODO: find a better place for this
+            // TODO: make this equal to the corresponding page's main graph color
+            self.graph.set_graph_color(28, 113, 216);
+            self.graph.push_data_point(usage);
         }
     }
 
@@ -101,6 +107,7 @@ mod imp {
                 image: Default::default(),
                 label: Default::default(),
                 progress_bar: Default::default(),
+                graph: Default::default(),
                 subtitle_label: Default::default(),
                 name: Default::default(),
                 subtitle: Default::default(),
@@ -166,6 +173,10 @@ impl ResStackSidebarItem {
 
     pub fn set_progress_bar_visible(&self, visible: bool) {
         self.imp().progress_bar.set_visible(visible);
+    }
+
+    pub fn set_graph_visible(&self, visible: bool) {
+        self.imp().graph.set_visible(visible);
     }
 
     pub fn set_subtitle_visible(&self, visible: bool) {

--- a/src/utils/settings.rs
+++ b/src/utils/settings.rs
@@ -127,6 +127,14 @@ impl RefreshSpeed {
     }
 }
 
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, EnumString, Display, Hash, FromRepr)]
+pub enum SidebarMeterType {
+    #[default]
+    ProgressBar,
+    Graph,
+}
+
 #[derive(Clone, Debug, Hash)]
 pub struct Settings(gio::Settings);
 
@@ -183,6 +191,29 @@ impl Settings {
         self.connect_changed(Some("refresh-speed"), move |settings, _key| {
             f(
                 RefreshSpeed::from_str(settings.string("refresh-speed").as_str())
+                    .unwrap_or_default(),
+            )
+        })
+    }
+
+    pub fn sidebar_meter_type(&self) -> SidebarMeterType {
+        SidebarMeterType::from_str(self.string("sidebar-meter-type").as_str()).unwrap_or_default()
+    }
+
+    pub fn set_sidebar_meter_type(
+        &self,
+        value: SidebarMeterType,
+    ) -> Result<(), glib::error::BoolError> {
+        self.set_string("sidebar-meter-type", &value.to_string())
+    }
+
+    pub fn connect_sidebar_meter_type<F: Fn(SidebarMeterType) + 'static>(
+        &self,
+        f: F,
+    ) -> glib::SignalHandlerId {
+        self.connect_changed(Some("sidebar-meter-type"), move |settings, _key| {
+            f(
+                SidebarMeterType::from_str(settings.string("sidebar-meter-type").as_str())
                     .unwrap_or_default(),
             )
         })


### PR DESCRIPTION
Taking some cues from the [Windows Task Manager](https://github.com/nokyan/resources/assets/662666/e7b50505-4ef9-4ada-b3d7-3d6f7b8e63b3), this adds a choice of having either a progress bar (current behavior, remains as the default) or a graph representing the same global "usage" for a resource (e.g. total CPU usage) in the sidebar item.

![Screenshot from 2023-12-25 16-18-43](https://github.com/nokyan/resources/assets/662666/ead095e6-d009-4e2e-84cc-3e1a760e9ef3)
![Screenshot from 2023-12-25 16-19-00](https://github.com/nokyan/resources/assets/662666/2c39312b-05c8-4772-910b-74b277517b6b)

Currently this is implemented by having an entirely separate `ResGraph` for the item, which may be non-optimal - ideally we could share the underlying data buffer with the page's graph.

My experience with GTK development is approximately zero, so feel free to be ruthless in your reviews :sweat_smile: 