### PR TITLE
Memory type set to <OUT OF SPEC> when not available

### DIFF
--- a/src/utils/memory.rs
+++ b/src/utils/memory.rs
@@ -232,7 +232,8 @@ fn parse_virtual_dmi<S: AsRef<str>>(dmi: S) -> Vec<MemoryDevice> {
             .ok()
             .and_then(|regex| regex.captures(dmi))
             .and_then(|captures| captures.get(1))
-            .map(|capture| capture.as_str().to_string());
+            .map(|capture| capture.as_str().to_string())
+            .filter(|capture| capture != "<OUT OF SPEC>");
 
         let type_detail = Regex::new(&TEMPLATE_RE_TYPE_DETAIL.replace('%', &i))
             .ok()


### PR DESCRIPTION
Hey, 

On the memory tab the memory type shows an empty string.
![Screenshot from 2023-12-29 16-42-23](https://github.com/nokyan/resources/assets/30468956/069ce006-5e2c-4850-9d68-fa34a28cb86f)

The udevadm command results in an "\<OUT OF SPEC\>" String. (and gtk4 doesn't display strings starting with < for some reason)
![Screenshot from 2023-12-29 15-50-10](https://github.com/nokyan/resources/assets/30468956/75fd17b4-4f4b-406a-b711-73b0919b81f5)

(However with dmidecode I get the expected "DDR5" result)

This should be the relevant udevadm source code: 
https://github.com/systemd/systemd/blob/6b9cac874c33f4fa27aa4b4b5b980f60c28ee043/src/udev/dmi_memory_id/dmi_memory_id.c#L307
In the list of supported memory types doesn't appear DDR5 which is strange. It should right? 
This String is only set for memory type errors, so it should be fine to add only one check.

My (not optimal) fix introduces a check if the type is "\<OUT OF SPEC\>" and displays N/A if so. I still think it is better to not show the type instead of having to permit sudo permissions for dmidecode then. 

My system specs: 
CPU: AMD Ryzen™ 7 7840U w/ Radeon™ 780M Graphics × 16
Memory: Kingston FURY Impact PnP 64GB (2x32GB) 5600MT/s DDR5 CL40 SODIMM (KF556S40IBK2-64)
Kernel: 6.6.8
udevadm --version : 255   (seems not right but why soever)
