### PR TITLE
Better appstream summary

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -631,7 +631,7 @@ to attach them to the start of each source file to most effectively
 state the exclusion of warranty; and each file should have at least
 the "copyright" line and a pointer to where the full notice is found.
 
-    Resources — Monitor your system resources and processes 
+    Resources — Keep an eye on system resources 
     Copyright (C) 2023  nokyan
 
     This program is free software: you can redistribute it and/or modify

--- a/data/net.nokyan.Resources.desktop.in.in
+++ b/data/net.nokyan.Resources.desktop.in.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Resources
-Comment=Monitor your system resources and processes
+Comment=Keep an eye on system resources
 Type=Application
 Exec=resources
 Terminal=false

--- a/data/net.nokyan.Resources.metainfo.xml.in.in
+++ b/data/net.nokyan.Resources.metainfo.xml.in.in
@@ -2,7 +2,8 @@
 <component type="desktop-application">
   <id>@app-id@</id>
   <name>Resources</name>
-  <summary>Monitor your system resources and processes</summary>
+  <!--Translators: The summary should be 35 characters or less according to Flathub appstream guidelines-->
+  <summary>Keep an eye on system resources</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
   <requires>

--- a/po/de.po
+++ b/po/de.po
@@ -6,7 +6,7 @@ msgstr ""
 "Project-Id-Version: resources\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-12-25 15:51+0100\n"
-"PO-Revision-Date: 2024-01-04 14:55+0100\n"
+"PO-Revision-Date: 2024-01-14 14:11+0100\n"
 "Last-Translator: nokyan <nokyan@tuta.io>\n"
 "Language-Team: German <nokyan@tuta.io>\n"
 "Language: de\n"
@@ -21,10 +21,11 @@ msgstr ""
 msgid "Resources"
 msgstr "Ressourcen"
 
+#. Translators: The summary should be 35 characters or less according to Flathub appstream guidelines
 #: data/net.nokyan.Resources.desktop.in.in:4
-#: data/net.nokyan.Resources.metainfo.xml.in.in:5
-msgid "Monitor your system resources and processes"
-msgstr "Systemressourcen und Prozesse überwachen"
+#: data/net.nokyan.Resources.metainfo.xml.in.in:6
+msgid "Keep an eye on system resources"
+msgstr "Systemressourcen im Auge behalten"
 
 #: data/net.nokyan.Resources.desktop.in.in:10
 msgid ""
@@ -187,7 +188,7 @@ msgstr "Raster in Graphen anzeigen"
 msgid "Amount of data points that should be shown in a graph"
 msgstr "Menge an Datenpunkten, die in Graphen angezeigt werden"
 
-#: data/net.nokyan.Resources.metainfo.xml.in.in:17
+#: data/net.nokyan.Resources.metainfo.xml.in.in:18
 msgid ""
 "Resources allows you to check the utilization of your system resources and "
 "control your running processes and applications. It’s designed to be user-"
@@ -199,15 +200,15 @@ msgstr ""
 "Durch die Verwendung von GNOMEs libadwaita ist Ressourcen einfach zu "
 "bedienen und fühlt sich auf einem modernen Desktop wie zu Hause an."
 
-#: data/net.nokyan.Resources.metainfo.xml.in.in:20
+#: data/net.nokyan.Resources.metainfo.xml.in.in:21
 msgid "Resources supports monitoring the following components:"
 msgstr "Ressourcen unterstützt das Überwachen folgender Komponenten:"
 
-#: data/net.nokyan.Resources.metainfo.xml.in.in:24 src/ui/pages/cpu.rs:221
+#: data/net.nokyan.Resources.metainfo.xml.in.in:25 src/ui/pages/cpu.rs:221
 msgid "CPU"
 msgstr "CPU"
 
-#: data/net.nokyan.Resources.metainfo.xml.in.in:25
+#: data/net.nokyan.Resources.metainfo.xml.in.in:26
 #: src/ui/pages/applications/mod.rs:628 src/ui/pages/memory.rs:116
 #: src/ui/pages/memory.rs:187 src/ui/pages/processes/mod.rs:710
 #: data/resources/ui/window.ui:155 data/resources/ui/window.ui:162
@@ -218,7 +219,7 @@ msgstr "CPU"
 msgid "Memory"
 msgstr "Arbeitsspeicher"
 
-#: data/net.nokyan.Resources.metainfo.xml.in.in:26
+#: data/net.nokyan.Resources.metainfo.xml.in.in:27
 #: src/ui/pages/applications/mod.rs:908 src/ui/pages/gpu.rs:138
 #: src/ui/pages/processes/mod.rs:1003 src/ui/window.rs:240
 #: data/resources/ui/dialogs/app_dialog.ui:132
@@ -228,12 +229,12 @@ msgstr "Arbeitsspeicher"
 msgid "GPU"
 msgstr "GPU"
 
-#: data/net.nokyan.Resources.metainfo.xml.in.in:27
+#: data/net.nokyan.Resources.metainfo.xml.in.in:28
 #: data/resources/ui/dialogs/settings_dialog.ui:266
 msgid "Network Interfaces"
 msgstr "Netzwerkschnittstellen"
 
-#: data/net.nokyan.Resources.metainfo.xml.in.in:28
+#: data/net.nokyan.Resources.metainfo.xml.in.in:29
 msgid "Storage Devices"
 msgstr "Datenträger"
 
@@ -256,7 +257,7 @@ msgid "Icon by"
 msgstr "Icon von"
 
 #: src/ui/dialogs/app_dialog.rs:163 src/ui/dialogs/process_dialog.rs:188
-#: src/ui/pages/drive.rs:259 src/ui/pages/drive.rs:265
+#: src/ui/pages/drive.rs:267 src/ui/pages/drive.rs:273
 msgid "No"
 msgstr "Nein"
 
@@ -275,7 +276,7 @@ msgstr "Ja (Snap)"
 #: src/ui/pages/applications/mod.rs:829 src/ui/pages/cpu.rs:222
 #: src/ui/pages/cpu.rs:237 src/ui/pages/cpu.rs:251 src/ui/pages/cpu.rs:257
 #: src/ui/pages/cpu.rs:263 src/ui/pages/cpu.rs:269 src/ui/pages/cpu.rs:273
-#: src/ui/pages/cpu.rs:276 src/ui/pages/cpu.rs:357 src/ui/pages/gpu.rs:240
+#: src/ui/pages/cpu.rs:276 src/ui/pages/cpu.rs:361 src/ui/pages/gpu.rs:240
 #: src/ui/pages/gpu.rs:285 src/ui/pages/gpu.rs:308 src/ui/pages/gpu.rs:311
 #: src/ui/pages/gpu.rs:322 src/ui/pages/gpu.rs:344 src/ui/pages/gpu.rs:354
 #: src/ui/pages/gpu.rs:366 src/ui/pages/gpu.rs:369 src/ui/pages/gpu.rs:375
@@ -377,7 +378,7 @@ msgstr "Videodekodierer"
 msgid "Video Memory"
 msgstr "Grafikspeicher"
 
-#: src/ui/pages/cpu.rs:236 src/ui/pages/cpu.rs:347
+#: src/ui/pages/cpu.rs:236 src/ui/pages/cpu.rs:347 src/ui/pages/cpu.rs:351
 msgid "CPU {}"
 msgstr "CPU {}"
 
@@ -389,13 +390,26 @@ msgstr "Speicher"
 msgid "Total Usage"
 msgstr "Gesamtauslastung"
 
-#: src/ui/pages/drive.rs:257 src/ui/pages/drive.rs:263
+#: src/ui/pages/drive.rs:223
+msgid "Read Speed"
+msgstr "Lesegeschwindigkeit"
+
+#: src/ui/pages/drive.rs:227
+msgid "Write Speed"
+msgstr "Schreibgeschwindigkeit"
+
+#: src/ui/pages/drive.rs:265 src/ui/pages/drive.rs:271
 msgid "Yes"
 msgstr "Ja"
 
+#: src/ui/pages/drive.rs:339 src/ui/pages/drive.rs:344
+#: src/ui/pages/network.rs:309 src/ui/pages/network.rs:318
+msgid "Highest:"
+msgstr "Höchste:"
+
 #. Translators: This is an abbreviation for "Read" and "Write". This is displayed in the sidebar so your
 #. translation should preferably be quite short or an abbreviation
-#: src/ui/pages/drive.rs:330
+#: src/ui/pages/drive.rs:352
 msgid "R: {} · W: {}"
 msgstr "L: {} · S: {}"
 
@@ -452,10 +466,6 @@ msgstr "Empfangen"
 #: src/ui/pages/network.rs:229
 msgid "Sending"
 msgstr "Senden"
-
-#: src/ui/pages/network.rs:309 src/ui/pages/network.rs:318
-msgid "Highest:"
-msgstr "Höchste:"
 
 #. Translators: This is an abbreviation for "Receive" and "Send". This is displayed in the sidebar so
 #. your translation should preferably be quite short or an abbreviation
@@ -1138,7 +1148,7 @@ msgstr "Auslastung"
 #: data/resources/ui/dialogs/app_dialog.ui:166
 #: data/resources/ui/dialogs/process_dialog.ui:149
 #: data/resources/ui/pages/applications.ui:26 data/resources/ui/pages/cpu.ui:91
-#: data/resources/ui/pages/drive.ui:48 data/resources/ui/pages/gpu.ui:80
+#: data/resources/ui/pages/drive.ui:36 data/resources/ui/pages/gpu.ui:80
 #: data/resources/ui/pages/memory.ui:42 data/resources/ui/pages/network.ui:51
 #: data/resources/ui/pages/processes.ui:26
 msgid "Properties"
@@ -1347,31 +1357,23 @@ msgstr "Virtualisierung"
 msgid "Architecture"
 msgstr "Architektur"
 
-#: data/resources/ui/pages/drive.ui:28
-msgid "Read Speed"
-msgstr "Lesegeschwindigkeit"
-
-#: data/resources/ui/pages/drive.ui:37
-msgid "Write Speed"
-msgstr "Schreibgeschwindigkeit"
-
-#: data/resources/ui/pages/drive.ui:51 data/resources/ui/pages/memory.ui:72
+#: data/resources/ui/pages/drive.ui:39 data/resources/ui/pages/memory.ui:72
 msgid "Type"
 msgstr "Typ"
 
-#: data/resources/ui/pages/drive.ui:60
+#: data/resources/ui/pages/drive.ui:48
 msgid "Device"
 msgstr "Gerät"
 
-#: data/resources/ui/pages/drive.ui:69
+#: data/resources/ui/pages/drive.ui:57
 msgid "Capacity"
 msgstr "Kapazität"
 
-#: data/resources/ui/pages/drive.ui:78
+#: data/resources/ui/pages/drive.ui:66
 msgid "Writable"
 msgstr "Schreibbar"
 
-#: data/resources/ui/pages/drive.ui:87
+#: data/resources/ui/pages/drive.ui:75
 msgid "Removable"
 msgstr "Wechselbar"
 
@@ -1466,6 +1468,9 @@ msgstr "Prozess fortsetzen"
 #: data/resources/ui/pages/processes.ui:111
 msgid "End Process"
 msgstr "Prozess beenden"
+
+#~ msgid "Monitor your system resources and processes"
+#~ msgstr "Systemressourcen und Prozesse überwachen"
 
 #~ msgid "Show Network Speeds in Bits"
 #~ msgstr "Netzwerkgeschwindigkeiten in Bits pro Sekunde anzeigen"

--- a/po/resources.pot
+++ b/po/resources.pot
@@ -6,8 +6,8 @@ msgstr ""
 "Project-Id-Version: resources\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-12-25 15:51+0100\n"
-"PO-Revision-Date: 2024-01-04 14:53+0200\n"
-"Last-Translator: nokyan <nokyan@tuta.io>\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
@@ -20,9 +20,10 @@ msgstr ""
 msgid "Resources"
 msgstr ""
 
+#. Translators: The summary should be 35 characters or less according to Flathub appstream guidelines
 #: data/net.nokyan.Resources.desktop.in.in:4
-#: data/net.nokyan.Resources.metainfo.xml.in.in:5
-msgid "Monitor your system resources and processes"
+#: data/net.nokyan.Resources.metainfo.xml.in.in:6
+msgid "Keep an eye on system resources"
 msgstr ""
 
 #: data/net.nokyan.Resources.desktop.in.in:10
@@ -184,7 +185,7 @@ msgstr ""
 msgid "Amount of data points that should be shown in a graph"
 msgstr ""
 
-#: data/net.nokyan.Resources.metainfo.xml.in.in:17
+#: data/net.nokyan.Resources.metainfo.xml.in.in:18
 msgid ""
 "Resources allows you to check the utilization of your system resources and "
 "control your running processes and applications. It’s designed to be user-"
@@ -192,15 +193,15 @@ msgid ""
 "libadwaita."
 msgstr ""
 
-#: data/net.nokyan.Resources.metainfo.xml.in.in:20
+#: data/net.nokyan.Resources.metainfo.xml.in.in:21
 msgid "Resources supports monitoring the following components:"
 msgstr ""
 
-#: data/net.nokyan.Resources.metainfo.xml.in.in:24 src/ui/pages/cpu.rs:221
+#: data/net.nokyan.Resources.metainfo.xml.in.in:25 src/ui/pages/cpu.rs:221
 msgid "CPU"
 msgstr ""
 
-#: data/net.nokyan.Resources.metainfo.xml.in.in:25
+#: data/net.nokyan.Resources.metainfo.xml.in.in:26
 #: src/ui/pages/applications/mod.rs:628 src/ui/pages/memory.rs:116
 #: src/ui/pages/memory.rs:187 src/ui/pages/processes/mod.rs:710
 #: data/resources/ui/window.ui:155 data/resources/ui/window.ui:162
@@ -211,7 +212,7 @@ msgstr ""
 msgid "Memory"
 msgstr ""
 
-#: data/net.nokyan.Resources.metainfo.xml.in.in:26
+#: data/net.nokyan.Resources.metainfo.xml.in.in:27
 #: src/ui/pages/applications/mod.rs:908 src/ui/pages/gpu.rs:138
 #: src/ui/pages/processes/mod.rs:1003 src/ui/window.rs:240
 #: data/resources/ui/dialogs/app_dialog.ui:132
@@ -221,12 +222,12 @@ msgstr ""
 msgid "GPU"
 msgstr ""
 
-#: data/net.nokyan.Resources.metainfo.xml.in.in:27
+#: data/net.nokyan.Resources.metainfo.xml.in.in:28
 #: data/resources/ui/dialogs/settings_dialog.ui:266
 msgid "Network Interfaces"
 msgstr ""
 
-#: data/net.nokyan.Resources.metainfo.xml.in.in:28
+#: data/net.nokyan.Resources.metainfo.xml.in.in:29
 msgid "Storage Devices"
 msgstr ""
 
@@ -249,7 +250,7 @@ msgid "Icon by"
 msgstr ""
 
 #: src/ui/dialogs/app_dialog.rs:163 src/ui/dialogs/process_dialog.rs:188
-#: src/ui/pages/drive.rs:259 src/ui/pages/drive.rs:265
+#: src/ui/pages/drive.rs:267 src/ui/pages/drive.rs:273
 msgid "No"
 msgstr ""
 
@@ -268,7 +269,7 @@ msgstr ""
 #: src/ui/pages/applications/mod.rs:829 src/ui/pages/cpu.rs:222
 #: src/ui/pages/cpu.rs:237 src/ui/pages/cpu.rs:251 src/ui/pages/cpu.rs:257
 #: src/ui/pages/cpu.rs:263 src/ui/pages/cpu.rs:269 src/ui/pages/cpu.rs:273
-#: src/ui/pages/cpu.rs:276 src/ui/pages/cpu.rs:357 src/ui/pages/gpu.rs:240
+#: src/ui/pages/cpu.rs:276 src/ui/pages/cpu.rs:361 src/ui/pages/gpu.rs:240
 #: src/ui/pages/gpu.rs:285 src/ui/pages/gpu.rs:308 src/ui/pages/gpu.rs:311
 #: src/ui/pages/gpu.rs:322 src/ui/pages/gpu.rs:344 src/ui/pages/gpu.rs:354
 #: src/ui/pages/gpu.rs:366 src/ui/pages/gpu.rs:369 src/ui/pages/gpu.rs:375
@@ -370,7 +371,7 @@ msgstr ""
 msgid "Video Memory"
 msgstr ""
 
-#: src/ui/pages/cpu.rs:236 src/ui/pages/cpu.rs:347
+#: src/ui/pages/cpu.rs:236 src/ui/pages/cpu.rs:347 src/ui/pages/cpu.rs:351
 msgid "CPU {}"
 msgstr ""
 
@@ -382,13 +383,26 @@ msgstr ""
 msgid "Total Usage"
 msgstr ""
 
-#: src/ui/pages/drive.rs:257 src/ui/pages/drive.rs:263
+#: src/ui/pages/drive.rs:223
+msgid "Read Speed"
+msgstr ""
+
+#: src/ui/pages/drive.rs:227
+msgid "Write Speed"
+msgstr ""
+
+#: src/ui/pages/drive.rs:265 src/ui/pages/drive.rs:271
 msgid "Yes"
+msgstr ""
+
+#: src/ui/pages/drive.rs:339 src/ui/pages/drive.rs:344
+#: src/ui/pages/network.rs:309 src/ui/pages/network.rs:318
+msgid "Highest:"
 msgstr ""
 
 #. Translators: This is an abbreviation for "Read" and "Write". This is displayed in the sidebar so your
 #. translation should preferably be quite short or an abbreviation
-#: src/ui/pages/drive.rs:330
+#: src/ui/pages/drive.rs:352
 msgid "R: {} · W: {}"
 msgstr ""
 
@@ -444,10 +458,6 @@ msgstr ""
 
 #: src/ui/pages/network.rs:229
 msgid "Sending"
-msgstr ""
-
-#: src/ui/pages/network.rs:309 src/ui/pages/network.rs:318
-msgid "Highest:"
 msgstr ""
 
 #. Translators: This is an abbreviation for "Receive" and "Send". This is displayed in the sidebar so
@@ -1127,7 +1137,7 @@ msgstr ""
 #: data/resources/ui/dialogs/app_dialog.ui:166
 #: data/resources/ui/dialogs/process_dialog.ui:149
 #: data/resources/ui/pages/applications.ui:26 data/resources/ui/pages/cpu.ui:91
-#: data/resources/ui/pages/drive.ui:48 data/resources/ui/pages/gpu.ui:80
+#: data/resources/ui/pages/drive.ui:36 data/resources/ui/pages/gpu.ui:80
 #: data/resources/ui/pages/memory.ui:42 data/resources/ui/pages/network.ui:51
 #: data/resources/ui/pages/processes.ui:26
 msgid "Properties"
@@ -1336,31 +1346,23 @@ msgstr ""
 msgid "Architecture"
 msgstr ""
 
-#: data/resources/ui/pages/drive.ui:28
-msgid "Read Speed"
-msgstr ""
-
-#: data/resources/ui/pages/drive.ui:37
-msgid "Write Speed"
-msgstr ""
-
-#: data/resources/ui/pages/drive.ui:51 data/resources/ui/pages/memory.ui:72
+#: data/resources/ui/pages/drive.ui:39 data/resources/ui/pages/memory.ui:72
 msgid "Type"
 msgstr ""
 
-#: data/resources/ui/pages/drive.ui:60
+#: data/resources/ui/pages/drive.ui:48
 msgid "Device"
 msgstr ""
 
-#: data/resources/ui/pages/drive.ui:69
+#: data/resources/ui/pages/drive.ui:57
 msgid "Capacity"
 msgstr ""
 
-#: data/resources/ui/pages/drive.ui:78
+#: data/resources/ui/pages/drive.ui:66
 msgid "Writable"
 msgstr ""
 
-#: data/resources/ui/pages/drive.ui:87
+#: data/resources/ui/pages/drive.ui:75
 msgid "Removable"
 msgstr ""
 


### PR DESCRIPTION
This PR changes Resources' appstream summary to be ≤ 35 characters, bringing it in line with [recent Flathub guideline changes](https://docs.flathub.org/blog/quality-moderation/). Resolves #149.