### PR TITLE
Update Brazilian Portuguese translation based on latest POT file

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1,14 +1,15 @@
 #
 # nokyan <nokyan@tuta.io>, 2023.
 # Victor L. Pavan <victorpavan001@gmail.com>, 2023-2024.
+# Filipe Motta <luizfilipemotta@gmail.com>, 2024.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: resources\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-25 15:51+0100\n"
-"PO-Revision-Date: 2024-01-06 00:12-0300\n"
-"Last-Translator: Victor L. Pavan <victorpavan001@gmail.com>\n"
+"POT-Creation-Date: 2024-01-24 13:26+0100\n"
+"PO-Revision-Date: 2024-01-30 01:56-0300\n"
+"Last-Translator: Filipe Motta <luizfilipemotta@gmail.com>\n"
 "Language-Team: Brazilian Portuguese <victorpavan001@gmail.com>\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
@@ -19,20 +20,22 @@ msgstr ""
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #: data/net.nokyan.Resources.desktop.in.in:3
-#: data/net.nokyan.Resources.metainfo.xml.in.in:4 src/application.rs:154
+#: data/net.nokyan.Resources.metainfo.xml.in.in:4 src/application.rs:196
 msgid "Resources"
 msgstr "Recursos"
 
+#. Translators: The summary should be 35 characters or less according to Flathub appstream guidelines
 #: data/net.nokyan.Resources.desktop.in.in:4
-#: data/net.nokyan.Resources.metainfo.xml.in.in:5
-msgid "Monitor your system resources and processes"
-msgstr "Monitore os recursos e processos de seu sistema"
+#: data/net.nokyan.Resources.metainfo.xml.in.in:6
+msgid "Keep an eye on system resources"
+msgstr "Monitore os recursos do sistema"
 
 #: data/net.nokyan.Resources.desktop.in.in:10
 msgid ""
 "System;Resources;Monitor;Processes;Usage;Task;Manager;CPU;RAM;Memory;GPU;"
 msgstr ""
-"Sistema;Recursos;Monitor;Processos;Uso;Tarefas;Admin;CPU;RAM;Memória;GPU;"
+"Sistema;Recursos;Monitor;Processos;Uso;Tarefas;Gerenciador;CPU;RAM;Memória;"
+"GPU;"
 
 #: data/net.nokyan.Resources.gschema.xml.in:6
 msgid "Window width"
@@ -52,21 +55,20 @@ msgstr "Unidade de temperatura"
 
 #: data/net.nokyan.Resources.gschema.xml.in:22
 msgid "Unit Prefix Base"
-msgstr "Prefixos de unidade base"
+msgstr "Base de Prefixo de Unidade"
 
 #: data/net.nokyan.Resources.gschema.xml.in:26
 #: data/resources/ui/dialogs/settings_dialog.ui:53
 msgid "Refresh Speed"
-msgstr "Taxa de atualização"
+msgstr "Taxa de Atualização"
 
 #: data/net.nokyan.Resources.gschema.xml.in:30
 msgid "Show search field for Processes and Applications on launch"
-msgstr ""
-"Mostrar campo de pesquisa para Processos e Aplicativos na inicialização"
+msgstr "Mostrar campo de pesquisa por Processos e Aplicativos ao iniciar"
 
 #: data/net.nokyan.Resources.gschema.xml.in:34
 msgid "Show virtual block devices such as LVM containers"
-msgstr "Mostrar dispositivos de bloco, como contêineres LVM"
+msgstr "Mostrar dispositivos de bloco virtuais, como contêineres LVM"
 
 #: data/net.nokyan.Resources.gschema.xml.in:38
 msgid "Show virtual network interfaces such as Docker interfaces"
@@ -83,135 +85,135 @@ msgstr "Mostrar descrição do dispositivo na barra lateral"
 #: data/net.nokyan.Resources.gschema.xml.in:50
 #: data/resources/ui/dialogs/settings_dialog.ui:103
 msgid "Sidebar Meter Type"
-msgstr "Tipo do medidor da barra lateral"
+msgstr "Tipo de Medidor da Barra Lateral"
 
 #: data/net.nokyan.Resources.gschema.xml.in:54
 msgid "Display network speeds in bits per second"
-msgstr "Mostrar velocidade de rede em bits por segundo"
+msgstr "Exibir velocidade de redes em bits por segundo"
 
 #: data/net.nokyan.Resources.gschema.xml.in:58
 msgid "Display memory usage in Applications view"
-msgstr "Mostrar uso de memória na visão de Aplicativos"
+msgstr "Exibir uso de memória na visão de Aplicativos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:62
 msgid "Display CPU usage in Applications view"
-msgstr "Mostrar uso de CPU na visão de Aplicativos"
+msgstr "Exibir uso de CPU na visão de Aplicativos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:66
 msgid "Display drive read speed in Applications view"
-msgstr "Mostrar velocidade de leitura na visão de Aplicativos"
+msgstr "Exibir velocidade de leitura na visão de Aplicativos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:70
 msgid "Display drive read total in Applications view"
-msgstr "Mostrar totais de leitura e gravação na visão de Aplicativos"
+msgstr "Exibir total de leitura na visão de Aplicativos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:74
 msgid "Display drive write speed in Applications view"
-msgstr "Mostrar velocidade de gravação na visão de Aplicativos"
+msgstr "Exibir velocidade de gravação na visão de Aplicativos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:78
 msgid "Display drive write total in Applications view"
-msgstr "Mostrar total de gravação na visão de Aplicativos"
+msgstr "Exibir total de gravação na visão de Aplicativos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:82
 msgid "Display GPU usage in Applications view"
-msgstr "Mostrar uso de GPU na visão de Aplicativos"
+msgstr "Exibir uso de GPU na visão de Aplicativos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:86
 msgid "Display video encoder usage in Applications view"
-msgstr "Mostrar codificação de video na visão de Aplicativos"
+msgstr "Exibir uso de codificador de vídeo na visão de Aplicativos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:90
 msgid "Display video decoder usage in Applications view"
-msgstr "Mostrar decodificação de video na visão de Aplicativos"
+msgstr "Exibir uso de decodificador de vídeo na visão de Aplicativos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:94
 msgid "Display GPU memory usage in Applications view"
-msgstr "Mostrar uso da memória de vídeo na visão de Aplicativos"
+msgstr "Exibir uso de memória de GPU na visão de Aplicativos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:98
 msgid "Display process ID in Processes view"
-msgstr "Mostrar ID do processo na visão de Processos"
+msgstr "Exibir ID de processo na visão de Processos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:102
 msgid "Display user name in Processes view"
-msgstr "Mostrar nome do Processo na visão de Processos"
+msgstr "Exibir nome de usuário na visão de Processos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:106
 msgid "Display memory usage in Processes view"
-msgstr "Mostrar uso da memória na visão de Processos"
+msgstr "Exibir uso de memória na visão de Processos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:110
 msgid "Display CPU usage in Processes view"
-msgstr "Mostrar uso da CPU na visão de Processos"
+msgstr "Exibir uso de CPU na visão de Processos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:114
 msgid "Display drive read speed in Processes view"
-msgstr "Mostrar velocidade de leitura na visão de Processos"
+msgstr "Exibir velocidade de leitura na visão de Processos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:118
 msgid "Display drive read total in Processes view"
-msgstr "Mostrar total de leitura na visão de Processos"
+msgstr "Exibir total de leitura na visão de Processos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:122
 msgid "Display drive write speed in Processes view"
-msgstr "Mostrar velocidade de gravação na visão de Processos"
+msgstr "Exibir velocidade de gravação na visão de Processos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:126
 msgid "Display drive write total in Processes view"
-msgstr "Mostrar total de gravação na visão de Processos"
+msgstr "Exibir total de gravação na visão de Processos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:130
 msgid "Display GPU usage in Processes view"
-msgstr "Mostrar uso da GPU na visão de Processos"
+msgstr "Exibir uso de GPU na visão de Processos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:134
 msgid "Display video encoder usage in Processes view"
-msgstr "Mostrar codificação de vídeo na visão de Processos"
+msgstr "Exibir uso de codificador de vídeo na visão de Processos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:138
 msgid "Display video decoder usage in Processes view"
-msgstr "Mostrar decodificação de vídeo na visão de Processos"
+msgstr "Exibir uso de decodificador de vídeo na visão de Processos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:142
 msgid "Display GPU memory usage in Processes view"
-msgstr "Mostrar uso da memória de vídeo na visão de processos"
+msgstr "Exibir uso de memória de GPU na visão de Processos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:146
 msgid "Display logical CPU graphs in Processor view"
-msgstr "Mostrar gráficos de CPUs lógicas na visão de Processador"
+msgstr "Exibir gráficos lógicos de CPU na visão de Processador"
 
 #: data/net.nokyan.Resources.gschema.xml.in:150
 msgid "Show grids in graphs"
-msgstr "Mostrar grade nos gráficos"
+msgstr "Exibir grades nos gráficos"
 
 #: data/net.nokyan.Resources.gschema.xml.in:154
 msgid "Amount of data points that should be shown in a graph"
-msgstr "Quantidade de pontos que devem ser mostrados nos gráficos"
+msgstr "Quantidade de pontos de dados a serem mostrados em um gráfico"
 
-#: data/net.nokyan.Resources.metainfo.xml.in.in:17
+#: data/net.nokyan.Resources.metainfo.xml.in.in:18
 msgid ""
 "Resources allows you to check the utilization of your system resources and "
 "control your running processes and applications. It’s designed to be user-"
 "friendly and feel right at home on a modern desktop by using GNOME’s "
 "libadwaita."
 msgstr ""
-"Recursos permite que você verifique a utilização dos recursos do sistema e "
+"Recursos permite que você verifique a utilização dos recursos do seu sistema e "
 "controle os processos e aplicativos em execução. É projetado para ter uma "
-"interface amigável e se encaixar em um desktop moderno, usando libadwaita do "
+"interface amigável e se encaixar em um desktop moderno, usando Libadwaita do "
 "GNOME."
 
-#: data/net.nokyan.Resources.metainfo.xml.in.in:20
+#: data/net.nokyan.Resources.metainfo.xml.in.in:21
 msgid "Resources supports monitoring the following components:"
 msgstr "Recursos suporta o monitoramento dos seguintes componentes:"
 
-#: data/net.nokyan.Resources.metainfo.xml.in.in:24 src/ui/pages/cpu.rs:221
+#: data/net.nokyan.Resources.metainfo.xml.in.in:25 src/ui/pages/cpu.rs:221
 msgid "CPU"
 msgstr "CPU"
 
-#: data/net.nokyan.Resources.metainfo.xml.in.in:25
-#: src/ui/pages/applications/mod.rs:628 src/ui/pages/memory.rs:116
-#: src/ui/pages/memory.rs:187 src/ui/pages/processes/mod.rs:710
+#: data/net.nokyan.Resources.metainfo.xml.in.in:26
+#: src/ui/pages/applications/mod.rs:629 src/ui/pages/memory.rs:116
+#: src/ui/pages/memory.rs:187 src/ui/pages/processes/mod.rs:714
 #: data/resources/ui/window.ui:155 data/resources/ui/window.ui:162
 #: data/resources/ui/dialogs/app_dialog.ui:83
 #: data/resources/ui/dialogs/process_dialog.ui:70
@@ -220,9 +222,9 @@ msgstr "CPU"
 msgid "Memory"
 msgstr "Memória"
 
-#: data/net.nokyan.Resources.metainfo.xml.in.in:26
-#: src/ui/pages/applications/mod.rs:908 src/ui/pages/gpu.rs:138
-#: src/ui/pages/processes/mod.rs:1003 src/ui/window.rs:240
+#: data/net.nokyan.Resources.metainfo.xml.in.in:27
+#: src/ui/pages/applications/mod.rs:909 src/ui/pages/gpu.rs:138
+#: src/ui/pages/processes/mod.rs:1007 src/ui/window.rs:277
 #: data/resources/ui/dialogs/app_dialog.ui:132
 #: data/resources/ui/dialogs/process_dialog.ui:115
 #: data/resources/ui/dialogs/settings_dialog.ui:157
@@ -230,35 +232,37 @@ msgstr "Memória"
 msgid "GPU"
 msgstr "GPU"
 
-#: data/net.nokyan.Resources.metainfo.xml.in.in:27
+#: data/net.nokyan.Resources.metainfo.xml.in.in:28
 #: data/resources/ui/dialogs/settings_dialog.ui:266
 msgid "Network Interfaces"
 msgstr "Interfaces de rede"
 
-#: data/net.nokyan.Resources.metainfo.xml.in.in:28
+#: data/net.nokyan.Resources.metainfo.xml.in.in:29
 msgid "Storage Devices"
 msgstr "Dispositivos de Armazenamento"
 
-#: src/application.rs:156
+#: src/application.rs:198
 msgid "The Nalux Team"
 msgstr "Equipe Nalux"
 
-#: src/application.rs:164
+#: src/application.rs:206
 msgid "Report Issues"
 msgstr "Reportar Problemas"
 
 #. Translator credits. Replace "translator-credits" with your name/username, and optionally an email or URL.
 #. One name per line, please do not remove previous names.
-#: src/application.rs:170
+#: src/application.rs:212
 msgid "translator-credits"
-msgstr "Victor Pavan <victorpavan001@gmail.com>"
+msgstr ""
+"Victor L. Pavan <victorpavan001@gmail.com>, 2023.\n"
+"Filipe Motta <luizfilipemotta@gmail.com>, 2024."
 
-#: src/application.rs:171
+#: src/application.rs:213
 msgid "Icon by"
 msgstr "Ícone por"
 
 #: src/ui/dialogs/app_dialog.rs:163 src/ui/dialogs/process_dialog.rs:188
-#: src/ui/pages/drive.rs:259 src/ui/pages/drive.rs:265
+#: src/ui/pages/drive.rs:267 src/ui/pages/drive.rs:273
 msgid "No"
 msgstr "Não"
 
@@ -273,11 +277,11 @@ msgstr "Sim (Snap)"
 #: src/ui/dialogs/process_dialog.rs:129 src/ui/dialogs/process_dialog.rs:136
 #: src/ui/dialogs/process_dialog.rs:143 src/ui/dialogs/process_dialog.rs:150
 #: src/ui/dialogs/process_dialog.rs:176 src/ui/dialogs/process_dialog.rs:183
-#: src/ui/dialogs/process_dialog.rs:185 src/ui/pages/applications/mod.rs:733
-#: src/ui/pages/applications/mod.rs:829 src/ui/pages/cpu.rs:222
+#: src/ui/dialogs/process_dialog.rs:185 src/ui/pages/applications/mod.rs:734
+#: src/ui/pages/applications/mod.rs:830 src/ui/pages/cpu.rs:222
 #: src/ui/pages/cpu.rs:237 src/ui/pages/cpu.rs:251 src/ui/pages/cpu.rs:257
 #: src/ui/pages/cpu.rs:263 src/ui/pages/cpu.rs:269 src/ui/pages/cpu.rs:273
-#: src/ui/pages/cpu.rs:276 src/ui/pages/cpu.rs:357 src/ui/pages/gpu.rs:240
+#: src/ui/pages/cpu.rs:276 src/ui/pages/cpu.rs:361 src/ui/pages/gpu.rs:240
 #: src/ui/pages/gpu.rs:285 src/ui/pages/gpu.rs:308 src/ui/pages/gpu.rs:311
 #: src/ui/pages/gpu.rs:322 src/ui/pages/gpu.rs:344 src/ui/pages/gpu.rs:354
 #: src/ui/pages/gpu.rs:366 src/ui/pages/gpu.rs:369 src/ui/pages/gpu.rs:375
@@ -288,9 +292,9 @@ msgstr "Sim (Snap)"
 #: src/ui/pages/memory.rs:251 src/ui/pages/memory.rs:305
 #: src/ui/pages/network.rs:238 src/ui/pages/network.rs:246
 #: src/ui/pages/network.rs:253 src/ui/pages/network.rs:260
-#: src/ui/pages/network.rs:263 src/ui/pages/processes/mod.rs:818
-#: src/ui/pages/processes/mod.rs:869 src/ui/pages/processes/mod.rs:920
-#: src/ui/pages/processes/mod.rs:971 src/utils/app.rs:674 src/utils/app.rs:750
+#: src/ui/pages/network.rs:263 src/ui/pages/processes/mod.rs:822
+#: src/ui/pages/processes/mod.rs:873 src/ui/pages/processes/mod.rs:924
+#: src/ui/pages/processes/mod.rs:975 src/utils/app.rs:674 src/utils/app.rs:750
 #: src/utils/drive.rs:90 src/utils/gpu/mod.rs:250 src/utils/gpu/mod.rs:256
 msgid "N/A"
 msgstr "N/D"
@@ -301,20 +305,20 @@ msgstr "N/D"
 msgid "Applications"
 msgstr "Aplicativos"
 
-#: src/ui/pages/applications/mod.rs:526
+#: src/ui/pages/applications/mod.rs:527
 msgid "Running Applications: {}"
 msgstr "Aplicativos em Execução: {}"
 
-#: src/ui/pages/applications/mod.rs:555 src/ui/pages/processes/mod.rs:538
+#: src/ui/pages/applications/mod.rs:556 src/ui/pages/processes/mod.rs:538
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/ui/pages/applications/mod.rs:582
+#: src/ui/pages/applications/mod.rs:583
 msgid "Application"
 msgstr "Aplicativo"
 
-#: src/ui/pages/applications/mod.rs:672 src/ui/pages/cpu.rs:136
-#: src/ui/pages/processes/mod.rs:757 src/ui/window.rs:279
+#: src/ui/pages/applications/mod.rs:673 src/ui/pages/cpu.rs:136
+#: src/ui/pages/processes/mod.rs:761 src/ui/window.rs:316
 #: data/resources/ui/window.ui:124 data/resources/ui/window.ui:131
 #: data/resources/ui/dialogs/app_dialog.ui:74
 #: data/resources/ui/dialogs/process_dialog.ui:61
@@ -323,7 +327,7 @@ msgstr "Aplicativo"
 msgid "Processor"
 msgstr "Processador"
 
-#: src/ui/pages/applications/mod.rs:715 src/ui/pages/processes/mod.rs:800
+#: src/ui/pages/applications/mod.rs:716 src/ui/pages/processes/mod.rs:804
 #: data/resources/ui/dialogs/app_dialog.ui:92
 #: data/resources/ui/dialogs/process_dialog.ui:75
 #: data/resources/ui/dialogs/settings_dialog.ui:137
@@ -331,7 +335,7 @@ msgstr "Processador"
 msgid "Drive Read"
 msgstr "Leitura"
 
-#: src/ui/pages/applications/mod.rs:765 src/ui/pages/processes/mod.rs:851
+#: src/ui/pages/applications/mod.rs:766 src/ui/pages/processes/mod.rs:855
 #: data/resources/ui/dialogs/app_dialog.ui:101
 #: data/resources/ui/dialogs/process_dialog.ui:84
 #: data/resources/ui/dialogs/settings_dialog.ui:142
@@ -339,7 +343,7 @@ msgstr "Leitura"
 msgid "Drive Read Total"
 msgstr "Total de Leitura"
 
-#: src/ui/pages/applications/mod.rs:811 src/ui/pages/processes/mod.rs:902
+#: src/ui/pages/applications/mod.rs:812 src/ui/pages/processes/mod.rs:906
 #: data/resources/ui/dialogs/app_dialog.ui:110
 #: data/resources/ui/dialogs/process_dialog.ui:93
 #: data/resources/ui/dialogs/settings_dialog.ui:147
@@ -347,7 +351,7 @@ msgstr "Total de Leitura"
 msgid "Drive Write"
 msgstr "Gravação"
 
-#: src/ui/pages/applications/mod.rs:862 src/ui/pages/processes/mod.rs:953
+#: src/ui/pages/applications/mod.rs:863 src/ui/pages/processes/mod.rs:957
 #: data/resources/ui/dialogs/app_dialog.ui:119
 #: data/resources/ui/dialogs/process_dialog.ui:102
 #: data/resources/ui/dialogs/settings_dialog.ui:152
@@ -355,23 +359,23 @@ msgstr "Gravação"
 msgid "Drive Write Total"
 msgstr "Total de Gravação"
 
-#: src/ui/pages/applications/mod.rs:951 src/ui/pages/processes/mod.rs:1046
+#: src/ui/pages/applications/mod.rs:952 src/ui/pages/processes/mod.rs:1050
 #: data/resources/ui/dialogs/app_dialog.ui:150
 #: data/resources/ui/dialogs/process_dialog.ui:133
 #: data/resources/ui/dialogs/settings_dialog.ui:167
 #: data/resources/ui/dialogs/settings_dialog.ui:238
 msgid "Video Encoder"
-msgstr "Codificação de Vídeo"
+msgstr "Codificador de Vídeo"
 
-#: src/ui/pages/applications/mod.rs:996 src/ui/pages/processes/mod.rs:1091
+#: src/ui/pages/applications/mod.rs:997 src/ui/pages/processes/mod.rs:1095
 #: data/resources/ui/dialogs/app_dialog.ui:159
 #: data/resources/ui/dialogs/process_dialog.ui:142
 #: data/resources/ui/dialogs/settings_dialog.ui:172
 #: data/resources/ui/dialogs/settings_dialog.ui:243
 msgid "Video Decoder"
-msgstr "Decodificação de Vídeo"
+msgstr "Decodificador de Vídeo"
 
-#: src/ui/pages/applications/mod.rs:1040 src/ui/pages/processes/mod.rs:1136
+#: src/ui/pages/applications/mod.rs:1041 src/ui/pages/processes/mod.rs:1140
 #: data/resources/ui/dialogs/app_dialog.ui:141
 #: data/resources/ui/dialogs/process_dialog.ui:124
 #: data/resources/ui/dialogs/settings_dialog.ui:162
@@ -379,7 +383,7 @@ msgstr "Decodificação de Vídeo"
 msgid "Video Memory"
 msgstr "Memória de Vídeo"
 
-#: src/ui/pages/cpu.rs:236 src/ui/pages/cpu.rs:347
+#: src/ui/pages/cpu.rs:236 src/ui/pages/cpu.rs:347 src/ui/pages/cpu.rs:351
 msgid "CPU {}"
 msgstr "CPU {}"
 
@@ -391,13 +395,26 @@ msgstr "Unidade"
 msgid "Total Usage"
 msgstr "Uso Total"
 
-#: src/ui/pages/drive.rs:257 src/ui/pages/drive.rs:263
+#: src/ui/pages/drive.rs:223
+msgid "Read Speed"
+msgstr "Velocidade de Leitura"
+
+#: src/ui/pages/drive.rs:227
+msgid "Write Speed"
+msgstr "Velocidade de Gravação"
+
+#: src/ui/pages/drive.rs:265 src/ui/pages/drive.rs:271
 msgid "Yes"
 msgstr "Sim"
 
+#: src/ui/pages/drive.rs:339 src/ui/pages/drive.rs:344
+#: src/ui/pages/network.rs:309 src/ui/pages/network.rs:318
+msgid "Highest:"
+msgstr "Máximo:"
+
 #. Translators: This is an abbreviation for "Read" and "Write". This is displayed in the sidebar so your
 #. translation should preferably be quite short or an abbreviation
-#: src/ui/pages/drive.rs:330
+#: src/ui/pages/drive.rs:352
 msgid "R: {} · W: {}"
 msgstr "L: {} · G: {}"
 
@@ -407,15 +424,15 @@ msgstr "Uso de GPU"
 
 #: src/ui/pages/gpu.rs:218
 msgid "Video Encoder/Decoder Usage"
-msgstr "Codificação/Decodificação de Vídeo"
+msgstr "Uso de Codificador/Decodificador de Vídeo"
 
 #: src/ui/pages/gpu.rs:224
 msgid "Video Encoder Usage"
-msgstr "Codificação de Vídeo"
+msgstr "Uso de Codificador de Vídeo"
 
 #: src/ui/pages/gpu.rs:229
 msgid "Video Decoder Usage"
-msgstr "Decodificação de Vídeo"
+msgstr "Uso de Decodificador de Vídeo"
 
 #: src/ui/pages/gpu.rs:234
 msgid "Video Memory Usage"
@@ -455,15 +472,11 @@ msgstr "Recebendo"
 msgid "Sending"
 msgstr "Enviando"
 
-#: src/ui/pages/network.rs:309 src/ui/pages/network.rs:318
-msgid "Highest:"
-msgstr "Máximo:"
-
 #. Translators: This is an abbreviation for "Receive" and "Send". This is displayed in the sidebar so
 #. your translation should preferably be quite short or an abbreviation
 #: src/ui/pages/network.rs:332
 msgid "R: {} · S: {}"
-msgstr "R: {} · T: {}"
+msgstr "R: {} · E: {}"
 
 #: src/ui/pages/processes/mod.rs:145 data/resources/ui/window.ui:93
 #: data/resources/ui/window.ui:100
@@ -475,135 +488,135 @@ msgstr "Processos"
 msgid "Running Processes: {}"
 msgstr "Processos em Execução: {}"
 
-#: src/ui/pages/processes/mod.rs:574
+#: src/ui/pages/processes/mod.rs:577
 msgid "root"
 msgstr "root"
 
-#: src/ui/pages/processes/mod.rs:587
+#: src/ui/pages/processes/mod.rs:591
 msgid "Process"
 msgstr "Processo"
 
-#: src/ui/pages/processes/mod.rs:633
+#: src/ui/pages/processes/mod.rs:637
 #: data/resources/ui/dialogs/process_dialog.ui:156
 #: data/resources/ui/dialogs/settings_dialog.ui:188
 msgid "Process ID"
 msgstr "ID do Processo"
 
-#: src/ui/pages/processes/mod.rs:671
+#: src/ui/pages/processes/mod.rs:675
 #: data/resources/ui/dialogs/process_dialog.ui:183
 #: data/resources/ui/dialogs/settings_dialog.ui:193
 msgid "User"
 msgstr "Usuário"
 
-#: src/ui/window.rs:238
+#: src/ui/window.rs:275
 msgid "GPU {}"
 msgstr "GPU {}"
 
-#: src/ui/window.rs:757
+#: src/ui/window.rs:794
 msgid "End {}?"
-msgstr "Finalizar {}?"
+msgstr "Encerrar {}?"
 
-#: src/ui/window.rs:758
+#: src/ui/window.rs:795
 msgid "Halt {}?"
 msgstr "Interromper {}?"
 
-#: src/ui/window.rs:759
+#: src/ui/window.rs:796
 msgid "Kill {}?"
 msgstr "Matar {}?"
 
-#: src/ui/window.rs:760
+#: src/ui/window.rs:797
 msgid "Continue {}?"
 msgstr "Continuar {}?"
 
-#: src/ui/window.rs:766
+#: src/ui/window.rs:803
 msgid "Unsaved work might be lost."
 msgstr "Trabalhos não salvos poderão ser perdidos."
 
-#: src/ui/window.rs:767
+#: src/ui/window.rs:804
 msgid ""
 "Halting an application can come with serious risks such as losing data and "
 "security implications. Use with caution."
 msgstr ""
-"Interromper um aplicação pode ter sérios riscos como perda de dados e "
-"implicações de segurança. Use com cuidado."
+"Interromper um aplicativo pode trazer sérios riscos, como perda de dados e "
+"implicações de segurança. Use esta opção com cautela."
 
-#: src/ui/window.rs:768
+#: src/ui/window.rs:805
 msgid ""
 "Killing an application can come with serious risks such as losing data and "
 "security implications. Use with caution."
 msgstr ""
-"Matar um aplicativo pode ter sérios riscos como perda de dados e implicações "
-"de segurança. Use esta opção com precaução."
+"Matar um aplicativo pode trazer sérios riscos, como perda de dados e "
+"implicações de segurança. Use esta opção com cautela."
 
-#: src/ui/window.rs:775
+#: src/ui/window.rs:812
 msgid "End application"
-msgstr "Finalizar Aplicativo"
+msgstr "Encerrar Aplicativo"
 
-#: src/ui/window.rs:776
+#: src/ui/window.rs:813
 msgid "Halt application"
 msgstr "Interromper Aplicativo"
 
-#: src/ui/window.rs:777
+#: src/ui/window.rs:814
 msgid "Kill application"
 msgstr "Matar Aplicativo"
 
-#: src/ui/window.rs:778
+#: src/ui/window.rs:815
 msgid "Continue application"
 msgstr "Continuar Aplicativo"
 
-#: src/ui/window.rs:784
+#: src/ui/window.rs:821
 msgid "Successfully ended {}"
-msgstr "{} finalizado com sucesso"
+msgstr "{} encerrado com sucesso"
 
-#: src/ui/window.rs:785
+#: src/ui/window.rs:822
 msgid "Successfully halted {}"
 msgstr "{} interrompido com sucesso"
 
-#: src/ui/window.rs:786
+#: src/ui/window.rs:823
 msgid "Successfully killed {}"
 msgstr "{} morto com sucesso"
 
-#: src/ui/window.rs:787
+#: src/ui/window.rs:824
 msgid "Successfully continued {}"
 msgstr "{} continuado com sucesso"
 
-#: src/ui/window.rs:794
+#: src/ui/window.rs:831
 msgid "There was a problem ending a process"
 msgid_plural "There were problems ending {} processes"
-msgstr[0] "Houve um problema ao finalizar um processo"
-msgstr[1] "Houveram problemas ao finalizar {} processos"
+msgstr[0] "Houve um problema ao encerrar um processo"
+msgstr[1] "Houve problemas ao encerrar {} processos"
 
-#: src/ui/window.rs:800
+#: src/ui/window.rs:837
 msgid "There was a problem halting a process"
 msgid_plural "There were problems halting {} processes"
 msgstr[0] "Houve um problema ao interromper um processo"
-msgstr[1] "Houveram problemas ao interromper {} processos"
+msgstr[1] "Houve problemas ao interromper {} processos"
 
-#: src/ui/window.rs:806
+#: src/ui/window.rs:843
 msgid "There was a problem killing a process"
 msgid_plural "There were problems killing {} processes"
 msgstr[0] "Houve um problema ao matar um processo"
-msgstr[1] "Houveram problemas ao matar {} processos"
+msgstr[1] "Houve problemas ao matar {} processos"
 
-#: src/ui/window.rs:812
+#: src/ui/window.rs:849
 msgid "There was a problem continuing a process"
 msgid_plural "There were problems continuing {} processes"
 msgstr[0] "Houve um problema ao continuar um processo"
-msgstr[1] "Houveram problemas ao continuar {} processos"
+msgstr[1] "Houve problemas ao continuar {} processos"
 
-#: src/ui/window.rs:822
+#: src/ui/window.rs:859
 msgid "There was a problem ending {}"
-msgstr "Houve um problema ao finalizar {}"
+msgstr "Houve um problema ao encerrar {}"
 
-#: src/ui/window.rs:823
+#: src/ui/window.rs:860
 msgid "There was a problem halting {}"
 msgstr "Houve um problema ao interromper {}"
 
-#: src/ui/window.rs:824
+#: src/ui/window.rs:861
 msgid "There was a problem killing {}"
 msgstr "Houve um problema ao matar {}"
 
-#: src/ui/window.rs:825
+#: src/ui/window.rs:862
 msgid "There was a problem continuing {}"
 msgstr "Houve um problema ao continuar {}"
 
@@ -645,7 +658,7 @@ msgstr "Unidade NVMe"
 
 #: src/utils/drive.rs:91
 msgid "Software Raid"
-msgstr "RAID Software"
+msgstr "RAID de Software"
 
 #: src/utils/drive.rs:92
 msgid "RAM Disk"
@@ -661,31 +674,31 @@ msgstr "Volume ZFS"
 
 #: src/utils/drive.rs:95
 msgid "Compressed RAM Disk (zram)"
-msgstr "Disco RAM comprimido"
+msgstr "Disco RAM Comprimido (zram)"
 
 #: src/utils/drive.rs:155
 msgid "{} Loop Device"
-msgstr "{} Dispositivo de Loop"
+msgstr "Dispositivo de Loop {}"
 
 #: src/utils/drive.rs:156
 msgid "{} Mapped Device"
-msgstr "{} Dispositivo Mapeado"
+msgstr "Dispositivo Mapeado {}"
 
 #: src/utils/drive.rs:157
 msgid "{} RAID"
-msgstr "{} RAID"
+msgstr "RAID {}"
 
 #: src/utils/drive.rs:158
 msgid "{} RAM Disk"
-msgstr "{} Disco RAM"
+msgstr "Disco RAM {}"
 
 #: src/utils/drive.rs:159
 msgid "{} zram Device"
-msgstr "{} dispositivo zram"
+msgstr "Dispositivo zram {}"
 
 #: src/utils/drive.rs:160
 msgid "{} ZFS Volume"
-msgstr "{} Volume ZFS"
+msgstr "Volume ZFS {}"
 
 #: src/utils/drive.rs:161
 msgid "{} Drive"
@@ -693,7 +706,7 @@ msgstr "Unidade {}"
 
 #: src/utils/network.rs:111
 msgid "Bluetooth Tether"
-msgstr "Bluetooth Tether"
+msgstr "Tether Bluetooth"
 
 #: src/utils/network.rs:112
 msgid "Network Bridge"
@@ -713,11 +726,11 @@ msgstr "Conexão Serial Line IP"
 
 #: src/utils/network.rs:116
 msgid "Virtual Ethernet Device"
-msgstr "Dispositivo Cabeado Virtual"
+msgstr "Dispositivo Ethernet Virtual"
 
 #: src/utils/network.rs:117
 msgid "VM Network Bridge"
-msgstr "Ponte de Rede da VM"
+msgstr "Ponte de Rede de VM"
 
 #: src/utils/network.rs:118
 msgid "VPN Tunnel"
@@ -922,11 +935,11 @@ msgstr "{} b/s"
 
 #: src/utils/units.rs:193
 msgid "{} kb/s"
-msgstr "{} kB/s"
+msgstr "{} kb/s"
 
 #: src/utils/units.rs:194
 msgid "{} Mb/s"
-msgstr "{} MB/s"
+msgstr "{} Mb/s"
 
 #: src/utils/units.rs:195
 msgid "{} Gb/s"
@@ -1111,7 +1124,32 @@ msgstr "Sair"
 #: data/resources/ui/shortcuts.ui:32
 msgctxt "shortcut window"
 msgid "Toggle Search Field"
-msgstr "Alternar campos de pesquisa"
+msgstr "Mostrar/Ocultar Campo de Pesquisa"
+
+#: data/resources/ui/shortcuts.ui:38
+msgctxt "shortcut window"
+msgid "End Application/Process"
+msgstr "Encerrar Aplicativo/Processo"
+
+#: data/resources/ui/shortcuts.ui:44
+msgctxt "shortcut window"
+msgid "Kill Application/Process"
+msgstr "Matar Aplicativo/Processo"
+
+#: data/resources/ui/shortcuts.ui:50
+msgctxt "shortcut window"
+msgid "Halt Application/Process"
+msgstr "Interromper Aplicativo/Processo"
+
+#: data/resources/ui/shortcuts.ui:56
+msgctxt "shortcut window"
+msgid "Continue Application/Process"
+msgstr "Continuar Aplicativo/Processo"
+
+#: data/resources/ui/shortcuts.ui:62
+msgctxt "shortcut window"
+msgid "Show Information for Application/Process"
+msgstr "Mostrar Informações sobre o Aplicativo/Processo"
 
 #: data/resources/ui/window.ui:6
 msgid "Preferences"
@@ -1119,7 +1157,7 @@ msgstr "Preferências"
 
 #: data/resources/ui/window.ui:10
 msgid "Keyboard Shortcuts"
-msgstr "Atalhos de Teclado"
+msgstr "Atalhos de teclado"
 
 #: data/resources/ui/window.ui:14
 msgid "About Resources"
@@ -1140,7 +1178,7 @@ msgstr "Uso"
 #: data/resources/ui/dialogs/app_dialog.ui:166
 #: data/resources/ui/dialogs/process_dialog.ui:149
 #: data/resources/ui/pages/applications.ui:26 data/resources/ui/pages/cpu.ui:91
-#: data/resources/ui/pages/drive.ui:48 data/resources/ui/pages/gpu.ui:80
+#: data/resources/ui/pages/drive.ui:36 data/resources/ui/pages/gpu.ui:80
 #: data/resources/ui/pages/memory.ui:42 data/resources/ui/pages/network.ui:51
 #: data/resources/ui/pages/processes.ui:26
 msgid "Properties"
@@ -1153,7 +1191,7 @@ msgstr "ID"
 #: data/resources/ui/dialogs/app_dialog.ui:182
 #: data/resources/ui/dialogs/process_dialog.ui:165
 msgid "Running Since"
-msgstr "Executando desde"
+msgstr "Em execução desde"
 
 #: data/resources/ui/dialogs/app_dialog.ui:190
 msgid "Running Processes"
@@ -1162,7 +1200,7 @@ msgstr "Processos em Execução"
 #: data/resources/ui/dialogs/app_dialog.ui:199
 #: data/resources/ui/dialogs/process_dialog.ui:201
 msgid "Containerized"
-msgstr "Em Container"
+msgstr "Em Contêiner"
 
 #: data/resources/ui/dialogs/process_dialog.ui:9
 msgid "Process Information"
@@ -1170,7 +1208,7 @@ msgstr "Informação do Processo"
 
 #: data/resources/ui/dialogs/process_dialog.ui:174
 msgid "Commandline"
-msgstr "Linha de comando"
+msgstr "Linha de Comando"
 
 #: data/resources/ui/dialogs/process_dialog.ui:192
 msgid "Control Group"
@@ -1186,7 +1224,7 @@ msgstr "Unidades"
 
 #: data/resources/ui/dialogs/settings_dialog.ui:16
 msgid "Data Unit Prefix"
-msgstr "Prefixo da Unidade dos Dados"
+msgstr "Prefixo de Unidade dos Dados"
 
 #: data/resources/ui/dialogs/settings_dialog.ui:20
 msgid "Decimal"
@@ -1198,7 +1236,7 @@ msgstr "Binário"
 
 #: data/resources/ui/dialogs/settings_dialog.ui:29
 msgid "Show Network Speeds in Bits per Second"
-msgstr "Mostrar velocidades de rede em bits/segundo"
+msgstr "Mostrar Velocidade de Redes em Bits por Segundo"
 
 #: data/resources/ui/dialogs/settings_dialog.ui:34
 msgid "Temperature Unit"
@@ -1218,7 +1256,7 @@ msgstr "Fahrenheit"
 
 #: data/resources/ui/dialogs/settings_dialog.ui:50
 msgid "User Interface"
-msgstr "Interface do Usuário"
+msgstr "Interface de Usuário"
 
 #: data/resources/ui/dialogs/settings_dialog.ui:57
 msgid "Very Slow"
@@ -1242,15 +1280,15 @@ msgstr "Muito Rápido"
 
 #: data/resources/ui/dialogs/settings_dialog.ui:69
 msgid "Show Graph Grids"
-msgstr "Mostrar Grades no Gráfico"
+msgstr "Mostrar Grades de Gráficos"
 
 #: data/resources/ui/dialogs/settings_dialog.ui:74
 msgid "Graph Data Points"
-msgstr "Mostrar Pontos no Gráfico"
+msgstr "Pontos de Dados dos Gráficos"
 
 #: data/resources/ui/dialogs/settings_dialog.ui:88
 msgid "Show Search Fields on Launch"
-msgstr "Mostrar Campos de Pesquisa na Inicialização"
+msgstr "Mostrar Campos de Pesquisa ao Iniciar"
 
 #: data/resources/ui/dialogs/settings_dialog.ui:93
 msgid "Show Usage Details in Sidebar"
@@ -1283,11 +1321,11 @@ msgstr "Unidades"
 
 #: data/resources/ui/dialogs/settings_dialog.ui:259
 msgid "Show Virtual Drives"
-msgstr "Mostrar unidades virtuais"
+msgstr "Mostrar Unidades Virtuais"
 
 #: data/resources/ui/dialogs/settings_dialog.ui:269
 msgid "Show Virtual Network Interfaces"
-msgstr "Mostrar interfaces de rede virtuais"
+msgstr "Mostrar Interfaces de Rede Virtuais"
 
 #: data/resources/ui/pages/applications.ui:6
 #: data/resources/ui/pages/applications.ui:36
@@ -1307,7 +1345,7 @@ msgstr "Continuar Aplicativo"
 #: data/resources/ui/pages/applications.ui:32
 #: data/resources/ui/pages/applications.ui:111
 msgid "End Application"
-msgstr "Finalizar Aplicativo"
+msgstr "Encerrar Aplicativo"
 
 #: data/resources/ui/pages/cpu.ui:22
 msgid "Options"
@@ -1315,7 +1353,7 @@ msgstr "Opções"
 
 #: data/resources/ui/pages/cpu.ui:26
 msgid "Show Usages of Logical CPUs"
-msgstr "Mostrar uso das CPU lógicas"
+msgstr "Mostrar Uso das CPUs Lógicas"
 
 #: data/resources/ui/pages/cpu.ui:77 data/resources/ui/pages/gpu.ui:66
 msgid "Sensors"
@@ -1349,31 +1387,23 @@ msgstr "Virtualização"
 msgid "Architecture"
 msgstr "Arquitetura"
 
-#: data/resources/ui/pages/drive.ui:28
-msgid "Read Speed"
-msgstr "Velocidade de Leitura"
-
-#: data/resources/ui/pages/drive.ui:37
-msgid "Write Speed"
-msgstr "Velocidade de Escrita"
-
-#: data/resources/ui/pages/drive.ui:51 data/resources/ui/pages/memory.ui:72
+#: data/resources/ui/pages/drive.ui:39 data/resources/ui/pages/memory.ui:72
 msgid "Type"
 msgstr "Tipo"
 
-#: data/resources/ui/pages/drive.ui:60
+#: data/resources/ui/pages/drive.ui:48
 msgid "Device"
 msgstr "Dispositivo"
 
-#: data/resources/ui/pages/drive.ui:69
+#: data/resources/ui/pages/drive.ui:57
 msgid "Capacity"
 msgstr "Capacidade"
 
-#: data/resources/ui/pages/drive.ui:78
+#: data/resources/ui/pages/drive.ui:66
 msgid "Writable"
 msgstr "Gravável"
 
-#: data/resources/ui/pages/drive.ui:87
+#: data/resources/ui/pages/drive.ui:75
 msgid "Removable"
 msgstr "Removível"
 
@@ -1419,7 +1449,7 @@ msgstr "Autenticar"
 
 #: data/resources/ui/pages/memory.ui:45
 msgid "Slots Used"
-msgstr "Soquetes utilizados"
+msgstr "Soquetes Utilizados"
 
 #: data/resources/ui/pages/memory.ui:54
 msgid "Speed"
@@ -1467,4 +1497,4 @@ msgstr "Continuar Processo"
 #: data/resources/ui/pages/processes.ui:32
 #: data/resources/ui/pages/processes.ui:111
 msgid "End Process"
-msgstr "Finalizar Proceso"
+msgstr "Encerrar Processo"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -254,7 +254,7 @@ msgstr "Reportar Problemas"
 #: src/application.rs:212
 msgid "translator-credits"
 msgstr ""
-"Victor L. Pavan <victorpavan001@gmail.com>, 2023.\n"
+"Victor L. Pavan <victorpavan001@gmail.com>, 2023-2024.\n"
 "Filipe Motta <luizfilipemotta@gmail.com>, 2024."
 
 #: src/application.rs:213


### PR DESCRIPTION
I have updated the Brazilian Portuguese translation based on the most recent POT file made available on the main repo.

This update includes a translation for the new AppStream description following Flathub's new guidelines.

It also includes a few revisions on the translation made by @fliperama00.
Some of them are stylistic choices to keep the translation more consistent with other GNOME apps, and some are actual fixes.

I'm willing to discuss any translation choices and I'm available to answer any questions regarding these choices.
I hope my efforts are useful to the community.