### PR TITLE
Change columnviews' background color

### DIFF
--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -1,3 +1,7 @@
 progressbar.slim > trough, progressbar.slim > trough > progress {
   min-height: 4px;
 }
+
+.resources-columnview {
+  background-color: @window_bg_color;
+}

--- a/src/ui/pages/applications/mod.rs
+++ b/src/ui/pages/applications/mod.rs
@@ -365,6 +365,8 @@ impl ResApplications {
             SETTINGS.apps_sort_by_ascending(),
         );
 
+        column_view.add_css_class("resources-columnview");
+
         *imp.store.borrow_mut() = store;
         *imp.selection_model.borrow_mut() = selection_model;
         *imp.sort_model.borrow_mut() = sort_model;

--- a/src/ui/pages/processes/mod.rs
+++ b/src/ui/pages/processes/mod.rs
@@ -375,6 +375,8 @@ impl ResProcesses {
             SETTINGS.processes_sort_by_ascending(),
         );
 
+        column_view.add_css_class("resources-columnview");
+
         *imp.store.borrow_mut() = store;
         *imp.selection_model.borrow_mut() = selection_model;
         *imp.sort_model.borrow_mut() = sort_model;


### PR DESCRIPTION
Ideally this should be done by changing style class from `view` to `background`, but for some reason this only changes columnview's header background. This custom style literally sets the same background color, as in `background` class.

![image](https://github.com/nokyan/resources/assets/64484944/48744f17-68a1-44dc-9099-1b383adac4b1)


fixes #17 