### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/net.nokyan.Resources.metainfo.xml.in.in
+++ b/data/net.nokyan.Resources.metainfo.xml.in.in
@@ -34,7 +34,7 @@
   <url type="vcs-browser">https://github.com/nokyan/resources</url>
   <url type="translate">https://github.com/nokyan/resources/tree/main/po</url>
   <content_rating type="oars-1.1"/>
-  <developer_name translatable="no">nokyan</developer_name>
+  <developer_name translate="no">nokyan</developer_name>
   <update_contact>nokyan@tuta.io</update_contact>
   <translation type="gettext">@gettext-package@</translation>
   <launchable type="desktop-id">@app-id@.desktop</launchable>
@@ -67,7 +67,7 @@
   </screenshots>
   <releases>
     <release version="1.3.0" date="2023-12-24">
-      <description translatable="no">
+      <description translate="no">
         <p>
           Resources 1.3 has been a long time in the making and brings a number of new and exciting features as well as many bug fixes. Enjoy!
         </p>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: `https://github.com/ximion/appstream/issues/623`

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html