### PR TITLE
fix: Use `AdwSwitchRow` for logical CPUs switch

### DIFF
--- a/data/resources/ui/pages/cpu.ui
+++ b/data/resources/ui/pages/cpu.ui
@@ -21,18 +21,10 @@
                   <object class="AdwPreferencesGroup">
                     <property name="title" translatable="yes">Options</property>
                     <child>
-                      <object class="AdwActionRow">
+                      <object class="AdwSwitchRow" id="logical_switch">
                         <property name="subtitle-selectable">true</property>
                         <property name="title" translatable="yes">Show Usages of Logical CPUs</property>
-                        <child type="suffix">
-                          <object class="GtkSwitch" id="logical_switch">
-                            <accessibility>
-                              <property name="label">Logical CPU switch</property>
-                            </accessibility>
-                            <property name="valign">3</property>
-                            <property name="sensitive">false</property>
-                          </object>
-                        </child>
+                        <property name="sensitive">false</property>
                       </object>
                     </child>
                   </object>

--- a/src/ui/pages/cpu.rs
+++ b/src/ui/pages/cpu.rs
@@ -28,7 +28,7 @@ mod imp {
     #[properties(wrapper_type = super::ResCPU)]
     pub struct ResCPU {
         #[template_child]
-        pub logical_switch: TemplateChild<gtk::Switch>,
+        pub logical_switch: TemplateChild<adw::SwitchRow>,
         #[template_child]
         pub stack: TemplateChild<gtk::Stack>,
         #[template_child]


### PR DESCRIPTION
I'm just tired of sniping this little switch. With `Adw.SwitchRow` the row itself is activatable.