### PR TITLE
Add an option to disable transitions between views

### DIFF
--- a/data/net.nokyan.Resources.gschema.xml.in
+++ b/data/net.nokyan.Resources.gschema.xml.in
@@ -189,5 +189,9 @@
       <default>true</default>
       <summary>Whether the CPU usage should be normalized (divided by the number of threads)</summary>
     </key>
+    <key name="enable-transitions" type="b">
+      <default>true</default>
+      <summary>Show transiitons when switching between views</summary>
+    </key>
   </schema>
 </schemalist>

--- a/data/resources/ui/dialogs/settings_dialog.ui
+++ b/data/resources/ui/dialogs/settings_dialog.ui
@@ -117,6 +117,12 @@
                 <property name="subtitle" translatable="yes">If enabled, the total usage of all cores will be divided by the amount of cores</property>
               </object>
             </child>
+            <child>
+              <object class="AdwSwitchRow" id="enable_transitions_row">
+                <property name="title" translatable="yes">Show Transitions when switching Views (requires restart)</property>
+                <property name="subtitle" translatable="yes">If enabled, switching between views will display a fading transition</property>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/src/ui/dialogs/settings_dialog.rs
+++ b/src/ui/dialogs/settings_dialog.rs
@@ -38,6 +38,8 @@ mod imp {
         pub sidebar_meter_type_row: TemplateChild<adw::ComboRow>,
         #[template_child]
         pub normalize_cpu_usage_row: TemplateChild<adw::SwitchRow>,
+        #[template_child]
+        pub enable_transitions_row: TemplateChild<adw::SwitchRow>,
 
         #[template_child]
         pub apps_show_memory_row: TemplateChild<adw::SwitchRow>,
@@ -173,6 +175,8 @@ impl ResSettingsDialog {
             .set_active(SETTINGS.show_search_on_start());
         imp.normalize_cpu_usage_row
             .set_active(SETTINGS.normalize_cpu_usage());
+        imp.enable_transitions_row
+            .set_active(SETTINGS.enable_transitions());
 
         imp.apps_show_memory_row
             .set_active(SETTINGS.apps_show_memory());
@@ -293,6 +297,11 @@ impl ResSettingsDialog {
         imp.normalize_cpu_usage_row
             .connect_active_notify(|switch_row| {
                 let _ = SETTINGS.set_normalize_cpu_usage(switch_row.is_active());
+            });
+        
+        imp.enable_transitions_row
+            .connect_active_notify(|switch_row| {
+                let _ = SETTINGS.set_enable_transitions(switch_row.is_active());
             });
 
         imp.apps_show_cpu_row.connect_active_notify(|switch_row| {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -567,8 +567,11 @@ impl MainWindow {
                 }
 
                 // enable the transition type only now to avoid having a transition right in the beginning
-                imp.content_stack
-                    .set_transition_type(gtk::StackTransitionType::Crossfade);
+                if SETTINGS.enable_transitions() {
+                    imp.content_stack
+                        .set_transition_type(gtk::StackTransitionType::Crossfade);
+                }
+
 
                 first_refresh = false;
             }

--- a/src/utils/settings.rs
+++ b/src/utils/settings.rs
@@ -359,7 +359,8 @@ impl Settings {
         processes_show_system_cpu_time,
         show_logical_cpus,
         show_graph_grids,
-        normalize_cpu_usage
+        normalize_cpu_usage,
+        enable_transitions
     );
 }
 


### PR DESCRIPTION
I've noticed that the fading transitions when switching between views are not consistent with other gnome apps and it also makes the app feel quite slow to me. While I understand that these transitions might be preferred by some, I believe it would be beneficial to give users more control over this behavior.

Therefore, I have implemented a new setting that allows users to disable these transitions:

![grafik](https://github.com/nokyan/resources/assets/46424671/8a9e343c-4cf7-4284-bb2f-a823c2976fdd)

However, as you can see written in the title of the setting, a restart is required for this change to take effect and I'm not sure if there is any way to make it work immediately, as my gnome/rust skills are basic at best.

Thanks for your consideration.
