### PR TITLE
Make files into FileIcons

### DIFF
--- a/src/utils/app.rs
+++ b/src/utils/app.rs
@@ -238,7 +238,7 @@ impl App {
         }
 
         let icon = if let Some(desktop_icon) = desktop_entry.get("Icon") {
-            if is_snap {
+            if is_snap || desktop_icon.starts_with('/') {
                 FileIcon::new(&File::for_path(desktop_icon)).into()
             } else {
                 ThemedIcon::new(desktop_icon).into()


### PR DESCRIPTION
The problem wasn't that the image was an `.svg` as originally thought. The problem is that the icons were absolute paths rather than resolvable icon names. Therefore we need to load it as the file that it is

@nokyan should we add more logic to this? I only forsee needing to handle `./`? or `~/` but I am not sure if those are supported.

fixes #291 