### PR TITLE
Round Graph Corners

### DIFF
--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -19,3 +19,7 @@ progressbar.slim > trough, progressbar.slim > trough > progress {
   min-height: 128px;
   border-radius: 50%;
 }
+
+.ResGraph, .ResGraphWrapper {
+  border-radius: 10px;
+}

--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -20,6 +20,14 @@ progressbar.slim > trough, progressbar.slim > trough > progress {
   border-radius: 50%;
 }
 
-.ResGraph, .ResGraphWrapper {
+.sidebar-graph {
+  border-radius: 5px;
+}
+
+.double-graph-box {
+  border-radius: 8px;
+}
+
+.res-graph {
   border-radius: 10px;
 }

--- a/data/resources/style.css
+++ b/data/resources/style.css
@@ -20,14 +20,14 @@ progressbar.slim > trough, progressbar.slim > trough > progress {
   border-radius: 50%;
 }
 
-.sidebar-graph {
-  border-radius: 5px;
+.small-graph {
+  border-radius: 4px;
 }
 
-.double-graph-box {
-  border-radius: 8px;
+.double-graph {
+  border-radius: 10px;
 }
 
-.res-graph {
+.graph {
   border-radius: 10px;
 }

--- a/data/resources/ui/widgets/double_graph_box.ui
+++ b/data/resources/ui/widgets/double_graph_box.ui
@@ -64,7 +64,7 @@
             <child>
               <object class="ResGraph" id="end_graph">
                 <style>
-                  <class name="double-graph-box"/>
+                  <class name="double-graph"/>
                 </style>
                 <property name="overflow">hidden</property>
                 <property name="hexpand">true</property>

--- a/data/resources/ui/widgets/double_graph_box.ui
+++ b/data/resources/ui/widgets/double_graph_box.ui
@@ -22,7 +22,7 @@
             <child>
               <object class="ResGraph" id="start_graph">
                 <style>
-                  <class name="ResGraph"/>
+                  <class name="double-graph-box"/>
                 </style>
                 <property name="overflow">hidden</property>
                 <property name="hexpand">true</property>
@@ -63,6 +63,10 @@
             <property name="spacing">12</property>
             <child>
               <object class="ResGraph" id="end_graph">
+                <style>
+                  <class name="double-graph-box"/>
+                </style>
+                <property name="overflow">hidden</property>
                 <property name="hexpand">true</property>
                 <property name="height-request">120</property>
               </object>

--- a/data/resources/ui/widgets/double_graph_box.ui
+++ b/data/resources/ui/widgets/double_graph_box.ui
@@ -21,6 +21,10 @@
             <property name="spacing">12</property>
             <child>
               <object class="ResGraph" id="start_graph">
+                <style>
+                  <class name="ResGraph"/>
+                </style>
+                <property name="overflow">hidden</property>
                 <property name="hexpand">true</property>
                 <property name="height-request">120</property>
               </object>

--- a/data/resources/ui/widgets/graph_box.ui
+++ b/data/resources/ui/widgets/graph_box.ui
@@ -17,7 +17,7 @@
         <child>
           <object class="ResGraph" id="graph">
             <style>
-              <class name="res-graph"/>
+              <class name="graph"/>
             </style>
             <property name="overflow">hidden</property>
             <property name="hexpand">true</property>

--- a/data/resources/ui/widgets/graph_box.ui
+++ b/data/resources/ui/widgets/graph_box.ui
@@ -17,7 +17,7 @@
         <child>
           <object class="ResGraph" id="graph">
             <style>
-              <class name="ResGraph"/>
+              <class name="res-graph"/>
             </style>
             <property name="overflow">hidden</property>
             <property name="hexpand">true</property>

--- a/data/resources/ui/widgets/graph_box.ui
+++ b/data/resources/ui/widgets/graph_box.ui
@@ -16,6 +16,10 @@
         <property name="hexpand">true</property>
         <child>
           <object class="ResGraph" id="graph">
+            <style>
+              <class name="ResGraph"/>
+            </style>
+            <property name="overflow">hidden</property>
             <property name="hexpand">true</property>
             <property name="height-request">120</property>
           </object>

--- a/data/resources/ui/widgets/stack_sidebar_item.ui
+++ b/data/resources/ui/widgets/stack_sidebar_item.ui
@@ -60,7 +60,7 @@
         <child>
           <object class="ResGraph" id="graph">
             <style>
-              <class name="sidebar-graph"/>
+              <class name="small-graph"/>
             </style>
             <property name="overflow">hidden</property>
             <property name="height-request">80</property>

--- a/data/resources/ui/widgets/stack_sidebar_item.ui
+++ b/data/resources/ui/widgets/stack_sidebar_item.ui
@@ -59,6 +59,10 @@
         </child>
         <child>
           <object class="ResGraph" id="graph">
+            <style>
+              <class name="ResGraph"/>
+            </style>
+            <property name="overflow">hidden</property>
             <property name="height-request">80</property>
           </object>
         </child>

--- a/data/resources/ui/widgets/stack_sidebar_item.ui
+++ b/data/resources/ui/widgets/stack_sidebar_item.ui
@@ -60,7 +60,7 @@
         <child>
           <object class="ResGraph" id="graph">
             <style>
-              <class name="ResGraph"/>
+              <class name="sidebar-graph"/>
             </style>
             <property name="overflow">hidden</property>
             <property name="height-request">80</property>

--- a/src/ui/pages/cpu.rs
+++ b/src/ui/pages/cpu.rs
@@ -258,6 +258,7 @@ impl ResCPU {
             let thread_box = ResGraphBox::new();
             thread_box.set_subtitle(&i18n_f("CPU {}", &[&(i + 1).to_string()]));
             thread_box.set_title_label(&i18n("N/A"));
+            thread_box.graph().set_css_classes(&["small-graph"]);
             thread_box.graph().set_height_request(72);
             thread_box.graph().set_graph_color(28, 113, 216);
             let flow_box_chld = FlowBoxChild::builder()


### PR DESCRIPTION
Fixes #254 

Solution: for each ResGraph, add a css class, give that css class rounded corners, and then hide any content of children that is outside the rounded corner.

Marking as draft to force discussion over ideal look and feel.