### PR TITLE
Restructure how Apps and Processes work internally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,18 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,12 +25,6 @@ checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "allocator-api2"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "anstream"
@@ -795,10 +777,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "heck"
@@ -1259,7 +1237,6 @@ dependencies = [
  "glob",
  "gtk-macros",
  "gtk4",
- "hashbrown",
  "libadwaita",
  "log",
  "nix",
@@ -1619,12 +1596,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1835,26 +1806,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a76ff259533532054cfbaefb115c613203c73707017459206380f03b3b3f266e"
 dependencies = [
  "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.7.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ gettext-rs = { version = "0.7", features = ["gettext-system"] }
 glob = "0.3.1"
 gtk = { version = "0.9.0", features = ["v4_10"], package = "gtk4" }
 gtk-macros = "0.3.0"
-hashbrown = "0.14.5"
 log = "0.4.22"
 nix = { version = "0.29.0", default-features = false, features = ["signal"] }
 num_cpus = "1.16.0"

--- a/build-aux/net.nokyan.Resources.Devel.json
+++ b/build-aux/net.nokyan.Resources.Devel.json
@@ -13,7 +13,7 @@
         "--env=G_MESSAGES_DEBUG=none",
         "--env=RUST_BACKTRACE=full",
         "--env=RUST_LOG=resources=debug",
-        "--env=XDG_DATA_DIRS=/app/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/usr/share:/run/host/share:/var/lib/flatpak/exports/share:~/.local/share/flatpak/exports/share:/var/lib/snapd/desktop",
+        "--env=XDG_DATA_DIRS=/app/share:/usr/share:/usr/share/runtime/share:/run/host/user-share:/run/host/usr/share:/run/host/share:/app/local/share:/usr/local/share:/usr/local/share/runtime/share:/run/host/usr/local/share:/run/host/local/share:/var/lib/flatpak/exports/share:~/.local/share/flatpak/exports/share:/var/lib/snapd/desktop",
         "--filesystem=/var/lib/snapd:ro",
         "--filesystem=/var/lib/flatpak/app:ro",
         "--filesystem=/var/lib/flatpak/exports/share:ro",

--- a/lib/process_data/Cargo.lock
+++ b/lib/process_data/Cargo.lock
@@ -13,15 +13,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.75"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "cc"
@@ -40,9 +40,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "darling"
-version = "0.10.2"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -50,27 +50,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.10.2"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.10.2"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -124,18 +124,18 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
 dependencies = [
  "cfg-if",
- "winapi 0.3.9",
+ "windows-targets",
 ]
 
 [[package]]
@@ -152,9 +152,9 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "nvml-wrapper"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd21b9f5a1cce3c3515c9ffa85f5c7443e07162dae0ccf4339bb7ca38ad3454"
+checksum = "0c9bff0aa1d48904a1385ea2a8b97576fbdcbc9a3cfccd0d31fe978e1c4038c5"
 dependencies = [
  "bitflags",
  "libloading",
@@ -166,31 +166,31 @@ dependencies = [
 
 [[package]]
 name = "nvml-wrapper-sys"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c961a2ea9e91c59a69b78e69090f6f5b867bb46c0c56de9482da232437c4987e"
+checksum = "698d45156f28781a4e79652b6ebe2eaa0589057d588d3aec1333f6466f13fcb5"
 dependencies = [
  "libloading",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "process-data"
-version = "1.3.0"
+version = "1.5.1"
 dependencies = [
  "anyhow",
  "glob",
@@ -207,18 +207,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.1"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaac441002f822bc9705a681810a4dd2963094b9ca0ddc41cb963a4c189189ea"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -228,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.2"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5011c7e263a695dc8ca064cddb722af1be54e517a280b12a5356f98366899e5d"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -245,22 +245,22 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "serde"
-version = "1.0.189"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e422a44e74ad4001bdc8eede9a4570ab52f71190e9c076d14369f38b9200537"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.189"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn",
 ]
 
 [[package]]
@@ -271,7 +271,7 @@ checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn",
 ]
 
 [[package]]
@@ -282,26 +282,15 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.9.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -310,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "syscalls"
-version = "0.6.15"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56b389b38331a454883a34fd19f25cbd1510b3510ff7aa28cb8d6de85d888439"
+checksum = "43d0e35dc7d73976a53c7e6d7d177ef804a0c0ee774ec77bcc520c2216fd7cbe"
 dependencies = [
  "serde",
  "serde_repr",
@@ -347,7 +336,7 @@ checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn",
 ]
 
 [[package]]
@@ -364,9 +353,9 @@ checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "uzers"
-version = "0.11.3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d283dc7e8c901e79e32d077866eaf599156cbf427fffa8289aecc52c5c3f63"
+checksum = "7d85875e16d59b3b1549efce83ff8251a64923b03bef94add0a1862847448de4"
 dependencies = [
  "libc",
  "log",
@@ -407,13 +396,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "wrapcenum-derive"
-version = "0.4.0"
+name = "windows-targets"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bcc065c85ad2c3bd12aa4118bf164835712e25080c392557801a13292c60aec"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wrapcenum-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76ff259533532054cfbaefb115c613203c73707017459206380f03b3b3f266e"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]

--- a/src/ui/dialogs/app_dialog.rs
+++ b/src/ui/dialogs/app_dialog.rs
@@ -1,12 +1,9 @@
+use crate::config::PROFILE;
+use crate::ui::pages::applications::application_entry::ApplicationEntry;
+use crate::utils::units::{convert_speed, convert_storage};
 use adw::{prelude::*, subclass::prelude::*};
 use gtk::gio::ThemedIcon;
 use gtk::glib;
-use process_data::Containerization;
-
-use crate::config::PROFILE;
-use crate::i18n::i18n;
-use crate::utils::app::AppItem;
-use crate::utils::units::{convert_speed, convert_storage};
 
 mod imp {
 
@@ -102,16 +99,16 @@ impl ResAppDialog {
         glib::Object::new::<Self>()
     }
 
-    pub fn init(&self, app: &AppItem) {
+    pub fn init(&self, app: &ApplicationEntry) {
         self.setup_widgets(app);
     }
 
-    pub fn setup_widgets(&self, app: &AppItem) {
+    pub fn setup_widgets(&self, app: &ApplicationEntry) {
         let imp = self.imp();
 
-        if app.id.is_none() // this will be the case for System Processes
+        if app.id().is_none() // this will be the case for System Processes
             || app
-                .icon
+                .icon()
                 .downcast_ref::<ThemedIcon>()
                 .is_some_and(|themed_icon| {
                     themed_icon
@@ -128,68 +125,63 @@ impl ResAppDialog {
             imp.icon.set_css_classes(&["big-bubble"]);
         }
 
-        imp.icon.set_from_gicon(&app.icon);
+        imp.icon.set_from_gicon(&app.icon());
 
-        imp.name.set_label(&app.display_name);
+        imp.name.set_label(&app.name());
 
-        if let Some(description) = &app.description {
+        if let Some(description) = &app.description() {
             imp.description.set_label(description);
         } else {
             imp.description.set_visible(false);
         }
 
-        if let Some(id) = &app.id {
+        if let Some(id) = &app.id() {
             imp.id.set_subtitle(id);
         } else {
             imp.id.set_visible(false);
         }
 
-        imp.running_since.set_subtitle(&app.running_since);
+        imp.running_since.set_subtitle(&app.running_since());
 
-        let containerized = match app.containerization {
-            Containerization::None => i18n("No"),
-            Containerization::Flatpak => i18n("Yes (Flatpak)"),
-            Containerization::Snap => i18n("Yes (Snap)"),
-        };
-        imp.containerized.set_subtitle(&containerized);
+        imp.containerized.set_subtitle(&app.containerization());
 
         self.update(app);
     }
 
-    pub fn update(&self, app: &AppItem) {
+    pub fn update(&self, app: &ApplicationEntry) {
         let imp = self.imp();
 
         imp.cpu_usage
-            .set_subtitle(&format!("{:.1} %", app.cpu_time_ratio * 100.0));
+            .set_subtitle(&format!("{:.1} %", app.cpu_usage() * 100.0));
 
         imp.memory_usage
-            .set_subtitle(&convert_storage(app.memory_usage as f64, false));
+            .set_subtitle(&convert_storage(app.memory_usage() as f64, false));
 
         imp.drive_read_speed
-            .set_subtitle(&convert_speed(app.read_speed, false));
+            .set_subtitle(&convert_speed(app.read_speed(), false));
 
         imp.drive_read_total
-            .set_subtitle(&convert_storage(app.read_total as f64, false));
+            .set_subtitle(&convert_storage(app.read_total() as f64, false));
 
         imp.drive_write_speed
-            .set_subtitle(&convert_speed(app.write_speed, false));
+            .set_subtitle(&convert_speed(app.write_speed(), false));
 
         imp.drive_write_total
-            .set_subtitle(&convert_storage(app.write_total as f64, false));
+            .set_subtitle(&convert_storage(app.write_total() as f64, false));
 
         imp.gpu_usage
-            .set_subtitle(&format!("{:.1} %", app.gpu_usage * 100.0));
+            .set_subtitle(&format!("{:.1} %", app.gpu_usage() * 100.0));
 
         imp.vram_usage
-            .set_subtitle(&convert_storage(app.gpu_mem_usage as f64, false));
+            .set_subtitle(&convert_storage(app.gpu_mem_usage() as f64, false));
 
         imp.encoder_usage
-            .set_subtitle(&format!("{:.1} %", app.enc_usage * 100.0));
+            .set_subtitle(&format!("{:.1} %", app.enc_usage() * 100.0));
 
         imp.decoder_usage
-            .set_subtitle(&format!("{:.1} %", app.dec_usage * 100.0));
+            .set_subtitle(&format!("{:.1} %", app.dec_usage() * 100.0));
 
         imp.processes_amount
-            .set_subtitle(&app.processes_amount.to_string());
+            .set_subtitle(&app.running_processes().to_string());
     }
 }

--- a/src/ui/dialogs/app_dialog.rs
+++ b/src/ui/dialogs/app_dialog.rs
@@ -1,4 +1,5 @@
 use crate::config::PROFILE;
+use crate::i18n::i18n;
 use crate::ui::pages::applications::application_entry::ApplicationEntry;
 use crate::utils::units::{convert_speed, convert_storage};
 use adw::{prelude::*, subclass::prelude::*};
@@ -141,7 +142,8 @@ impl ResAppDialog {
             imp.id.set_visible(false);
         }
 
-        imp.running_since.set_subtitle(&app.running_since());
+        imp.running_since
+            .set_subtitle(&app.running_since().unwrap_or_else(|| i18n("N/A").into()));
 
         imp.containerized.set_subtitle(&app.containerization());
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,43 @@
+extern crate paste;
+
+#[macro_export]
+macro_rules! gstring_getter_setter {
+    ($($gstring_name:ident),*) => {
+        $(
+            pub fn $gstring_name(&self) -> glib::GString {
+                let $gstring_name = self.$gstring_name.take();
+                self.$gstring_name.set($gstring_name.clone());
+                $gstring_name
+            }
+
+            paste::paste! {
+                pub fn [<set_ $gstring_name>](&self, $gstring_name: &str) {
+                    self.$gstring_name.set(glib::GString::from($gstring_name));
+                }
+            }
+        )*
+    };
+}
+
+#[macro_export]
+macro_rules! gstring_option_getter_setter {
+    ($($gstring_name:ident),*) => {
+        $(
+            pub fn $gstring_name(&self) -> Option<glib::GString> {
+                let $gstring_name = self.$gstring_name.take();
+                self.$gstring_name.set($gstring_name.clone());
+                $gstring_name
+            }
+
+            paste::paste! {
+                pub fn [<set_ $gstring_name>](&self, $gstring_name: Option<&str>) {
+                    self.$gstring_name.set($gstring_name.map(glib::GString::from));
+                }
+            }
+        )*
+    };
+}
+
 pub mod dialogs;
 pub mod pages;
 pub mod widgets;

--- a/src/ui/pages/applications/mod.rs
+++ b/src/ui/pages/applications/mod.rs
@@ -739,6 +739,11 @@ impl ResApplications {
                 .bind(&row, "symbolic", Widget::NONE);
         });
 
+        name_col_factory.connect_teardown(move |_factory, item| {
+            let item = item.downcast_ref::<gtk::ListItem>();
+            item.unwrap().set_child(None::<&ResApplicationNameCell>);
+        });
+
         let name_col_sorter = StringSorter::builder()
             .ignore_case(true)
             .expression(gtk::PropertyExpression::new(
@@ -778,6 +783,11 @@ impl ResApplications {
                     convert_storage(memory_usage as f64, false)
                 }))
                 .bind(&row, "text", Widget::NONE);
+        });
+
+        memory_col_factory.connect_teardown(move |_factory, item| {
+            let item = item.downcast_ref::<gtk::ListItem>();
+            item.unwrap().set_child(None::<&gtk::Inscription>);
         });
 
         let memory_col_sorter = NumericSorter::builder()
@@ -830,6 +840,11 @@ impl ResApplications {
                     format!("{percentage:.1} %")
                 }))
                 .bind(&row, "text", Widget::NONE);
+        });
+
+        cpu_col_factory.connect_teardown(move |_factory, item| {
+            let item = item.downcast_ref::<gtk::ListItem>();
+            item.unwrap().set_child(None::<&gtk::Inscription>);
         });
 
         let cpu_col_sorter = NumericSorter::builder()
@@ -885,6 +900,11 @@ impl ResApplications {
                 .bind(&row, "text", Widget::NONE);
         });
 
+        read_speed_col_factory.connect_teardown(move |_factory, item| {
+            let item = item.downcast_ref::<gtk::ListItem>();
+            item.unwrap().set_child(None::<&gtk::Inscription>);
+        });
+
         let read_speed_col_sorter = NumericSorter::builder()
             .sort_order(SortType::Ascending)
             .expression(gtk::PropertyExpression::new(
@@ -932,6 +952,11 @@ impl ResApplications {
                     convert_storage(read_total as f64, false)
                 }))
                 .bind(&row, "text", Widget::NONE);
+        });
+
+        read_total_col_factory.connect_teardown(move |_factory, item| {
+            let item = item.downcast_ref::<gtk::ListItem>();
+            item.unwrap().set_child(None::<&gtk::Inscription>);
         });
 
         let read_total_col_sorter = NumericSorter::builder()
@@ -987,6 +1012,11 @@ impl ResApplications {
                 .bind(&row, "text", Widget::NONE);
         });
 
+        write_speed_col_factory.connect_teardown(move |_factory, item| {
+            let item = item.downcast_ref::<gtk::ListItem>();
+            item.unwrap().set_child(None::<&gtk::Inscription>);
+        });
+
         let write_speed_col_sorter = NumericSorter::builder()
             .sort_order(SortType::Ascending)
             .expression(gtk::PropertyExpression::new(
@@ -1038,6 +1068,11 @@ impl ResApplications {
                 .bind(&row, "text", Widget::NONE);
         });
 
+        write_total_col_factory.connect_teardown(move |_factory, item| {
+            let item = item.downcast_ref::<gtk::ListItem>();
+            item.unwrap().set_child(None::<&gtk::Inscription>);
+        });
+
         let write_total_col_sorter = NumericSorter::builder()
             .sort_order(SortType::Ascending)
             .expression(gtk::PropertyExpression::new(
@@ -1084,6 +1119,11 @@ impl ResApplications {
                     format!("{:.1} %", gpu_usage * 100.0)
                 }))
                 .bind(&row, "text", Widget::NONE);
+        });
+
+        gpu_col_factory.connect_teardown(move |_factory, item| {
+            let item = item.downcast_ref::<gtk::ListItem>();
+            item.unwrap().set_child(None::<&gtk::Inscription>);
         });
 
         let gpu_col_sorter = NumericSorter::builder()
@@ -1135,6 +1175,11 @@ impl ResApplications {
                 .bind(&row, "text", Widget::NONE);
         });
 
+        encoder_col_factory.connect_teardown(move |_factory, item| {
+            let item = item.downcast_ref::<gtk::ListItem>();
+            item.unwrap().set_child(None::<&gtk::Inscription>);
+        });
+
         let encoder_col_sorter = NumericSorter::builder()
             .sort_order(SortType::Ascending)
             .expression(gtk::PropertyExpression::new(
@@ -1184,6 +1229,11 @@ impl ResApplications {
                 .bind(&row, "text", Widget::NONE);
         });
 
+        decoder_col_factory.connect_teardown(move |_factory, item| {
+            let item = item.downcast_ref::<gtk::ListItem>();
+            item.unwrap().set_child(None::<&gtk::Inscription>);
+        });
+
         let decoder_col_sorter = NumericSorter::builder()
             .sort_order(SortType::Ascending)
             .expression(gtk::PropertyExpression::new(
@@ -1228,6 +1278,11 @@ impl ResApplications {
                     convert_storage(gpu_mem as f64, false)
                 }))
                 .bind(&row, "text", Widget::NONE);
+        });
+
+        gpu_mem_col_factory.connect_teardown(move |_factory, item| {
+            let item = item.downcast_ref::<gtk::ListItem>();
+            item.unwrap().set_child(None::<&gtk::Inscription>);
         });
 
         let gpu_mem_col_sorter = NumericSorter::builder()

--- a/src/ui/pages/processes/process_entry.rs
+++ b/src/ui/pages/processes/process_entry.rs
@@ -1,12 +1,13 @@
-use gtk::{
-    glib::{self},
-    subclass::prelude::ObjectSubclassIsExt,
+use gtk::glib::{self, GString};
+use process_data::Containerization;
+
+use crate::{
+    i18n::i18n,
+    utils::{process::Process, TICK_RATE},
 };
 
-use crate::utils::process::ProcessItem;
-
 mod imp {
-    use std::cell::{Cell, RefCell};
+    use std::cell::Cell;
 
     use gtk::{
         gio::{Icon, ThemedIcon},
@@ -74,7 +75,14 @@ mod imp {
         #[property(get, set)]
         system_cpu_time: Cell<f64>,
 
-        pub process_item: RefCell<Option<ProcessItem>>,
+        #[property(get = Self::cgroup, set = Self::set_cgroup)]
+        cgroup: Cell<Option<glib::GString>>,
+
+        #[property(get = Self::containerization, set = Self::set_containerization)]
+        containerization: Cell<glib::GString>,
+
+        #[property(get = Self::running_since, set = Self::set_running_since)]
+        running_since: Cell<Option<glib::GString>>,
     }
 
     impl Default for ProcessEntry {
@@ -87,7 +95,6 @@ mod imp {
                 pid: Cell::new(0),
                 cpu_usage: Cell::new(0.0),
                 memory_usage: Cell::new(0),
-                process_item: RefCell::new(None),
                 read_speed: Cell::new(0.0),
                 read_total: Cell::new(0),
                 write_speed: Cell::new(0.0),
@@ -99,40 +106,16 @@ mod imp {
                 total_cpu_time: Cell::new(0.0),
                 user_cpu_time: Cell::new(0.0),
                 system_cpu_time: Cell::new(0.0),
+                cgroup: Cell::new(None),
+                containerization: Cell::new(glib::GString::default()),
+                running_since: Cell::new(None),
             }
         }
     }
 
     impl ProcessEntry {
-        pub fn name(&self) -> glib::GString {
-            let name = self.name.take();
-            self.name.set(name.clone());
-            name
-        }
-
-        pub fn set_name(&self, name: &str) {
-            self.name.set(glib::GString::from(name));
-        }
-
-        pub fn commandline(&self) -> glib::GString {
-            let commandline = self.commandline.take();
-            self.commandline.set(commandline.clone());
-            commandline
-        }
-
-        pub fn set_commandline(&self, commandline: &str) {
-            self.commandline.set(glib::GString::from(commandline));
-        }
-
-        pub fn user(&self) -> glib::GString {
-            let user = self.user.take();
-            self.user.set(user.clone());
-            user
-        }
-
-        pub fn set_user(&self, user: &str) {
-            self.user.set(glib::GString::from(user));
-        }
+        gstring_getter_setter!(user, commandline, name, containerization);
+        gstring_option_getter_setter!(cgroup, running_since);
 
         pub fn icon(&self) -> Icon {
             let icon = self.icon.replace(ThemedIcon::new("generic-process").into());
@@ -175,48 +158,56 @@ glib::wrapper! {
 }
 
 impl ProcessEntry {
-    pub fn new(process_item: ProcessItem) -> Self {
+    pub fn new(process: &Process) -> Self {
+        let display_name = if process.executable_name.starts_with(&process.data.comm) {
+            process.executable_name.clone()
+        } else {
+            process.data.comm.clone()
+        };
+
+        let containerization = match process.data.containerization {
+            Containerization::None => i18n("No"),
+            Containerization::Flatpak => i18n("Yes (Flatpak)"),
+            Containerization::Snap => i18n("Yes (Snap)"),
+        };
+
         let this: Self = glib::Object::builder()
-            .property("name", &process_item.display_name)
-            .property("commandline", &process_item.commandline)
-            .property("user", &process_item.user)
-            .property("icon", &process_item.icon)
-            .property("pid", process_item.pid)
+            .property("name", &display_name)
+            .property("commandline", process.data.commandline.replace('\0', " "))
+            .property("user", &process.data.user)
+            .property("icon", &process.icon)
+            .property("pid", process.data.pid)
+            .property("cgroup", process.data.cgroup.clone().map(GString::from))
+            .property("containerization", containerization)
+            .property("running_since", process.running_since().ok())
             .build();
-        this.update(process_item);
+        this.update(process);
         this
     }
 
-    pub fn update(&self, process_item: ProcessItem) {
-        self.set_cpu_usage(process_item.cpu_time_ratio);
-        self.set_memory_usage(process_item.memory_usage as u64);
-        self.set_read_speed(process_item.read_speed.unwrap_or(-1.0));
+    pub fn update(&self, process: &Process) {
+        self.set_cpu_usage(process.cpu_time_ratio());
+        self.set_memory_usage(process.data.memory_usage as u64);
+        self.set_read_speed(process.read_speed().unwrap_or(-1.0));
         self.set_read_total(
-            process_item
-                .read_total
+            process
+                .data
+                .read_bytes
                 .map_or(-1, |read_total| read_total as i64),
         );
-        self.set_write_speed(process_item.write_speed.unwrap_or(-1.0));
+        self.set_write_speed(process.write_speed().unwrap_or(-1.0));
         self.set_write_total(
-            process_item
-                .write_total
+            process
+                .data
+                .write_bytes
                 .map_or(-1, |write_total| write_total as i64),
         );
-        self.set_gpu_usage(process_item.gpu_usage);
-        self.set_enc_usage(process_item.enc_usage);
-        self.set_dec_usage(process_item.dec_usage);
-        self.set_gpu_mem_usage(process_item.gpu_mem_usage);
-        self.set_total_cpu_time(process_item.user_cpu_time + process_item.system_cpu_time);
-        self.set_user_cpu_time(process_item.user_cpu_time);
-        self.set_system_cpu_time(process_item.system_cpu_time);
-
-        self.imp().process_item.replace(Some(process_item));
-    }
-
-    pub fn process_item(&self) -> Option<ProcessItem> {
-        let imp = self.imp();
-        let item = imp.process_item.take();
-        imp.process_item.replace(item.clone());
-        item
+        self.set_gpu_usage(process.gpu_usage());
+        self.set_enc_usage(process.enc_usage());
+        self.set_dec_usage(process.dec_usage());
+        self.set_gpu_mem_usage(process.gpu_mem_usage());
+        self.set_user_cpu_time((process.data.user_cpu_time as f64) / (*TICK_RATE as f64));
+        self.set_system_cpu_time((process.data.system_cpu_time as f64) / (*TICK_RATE as f64));
+        self.set_total_cpu_time(self.user_cpu_time() + self.system_cpu_time());
     }
 }

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -247,9 +247,9 @@ impl MainWindow {
         let selected_page = self.get_selected_page().unwrap();
 
         if selected_page.is::<ResApplications>() {
-            if let Some(app_item) = imp.applications.get_selected_app_item() {
+            if let Some(app_item) = imp.applications.get_selected_app_entry() {
                 imp.applications
-                    .execute_process_action_dialog(app_item, process_action);
+                    .execute_process_action_dialog(&app_item, process_action);
             }
         } else if selected_page.is::<ResProcesses>() {
             if let Some(process_item) = imp.processes.get_selected_process_item() {
@@ -265,7 +265,7 @@ impl MainWindow {
         let selected_page = self.get_selected_page().unwrap();
 
         if selected_page.is::<ResApplications>() {
-            if let Some(app_item) = imp.applications.get_selected_app_item() {
+            if let Some(app_item) = imp.applications.get_selected_app_entry() {
                 imp.applications.open_information_dialog(&app_item);
             }
         } else if selected_page.is::<ResProcesses>() {
@@ -835,7 +835,7 @@ impl MainWindow {
             }
 
             Action::ManipulateApp(action, id, toast_overlay) => {
-                let app = apps_context.get_app(&id).unwrap();
+                let app = apps_context.get_app(&Some(id.clone())).unwrap();
                 let res = app.execute_process_action(&apps_context, action);
 
                 for r in &res {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -252,9 +252,9 @@ impl MainWindow {
                     .execute_process_action_dialog(&app_item, process_action);
             }
         } else if selected_page.is::<ResProcesses>() {
-            if let Some(process_item) = imp.processes.get_selected_process_item() {
+            if let Some(process_item) = imp.processes.get_selected_process_entry() {
                 imp.processes
-                    .execute_process_action_dialog(process_item, process_action);
+                    .execute_process_action_dialog(&process_item, process_action);
             }
         }
     }
@@ -269,7 +269,7 @@ impl MainWindow {
                 imp.applications.open_information_dialog(&app_item);
             }
         } else if selected_page.is::<ResProcesses>() {
-            if let Some(process_item) = imp.processes.get_selected_process_item() {
+            if let Some(process_item) = imp.processes.get_selected_process_entry() {
                 imp.processes.open_information_dialog(&process_item);
             }
         }

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -1,4 +1,3 @@
-use hashbrown::HashMap;
 use process_data::ProcessData;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -38,7 +37,7 @@ pub enum Action {
 }
 
 mod imp {
-    use std::cell::RefCell;
+    use std::{cell::RefCell, collections::HashMap};
 
     use crate::{
         ui::{

--- a/src/utils/app.rs
+++ b/src/utils/app.rs
@@ -119,34 +119,8 @@ static MESSAGE_LOCALES: LazyLock<Vec<String>> = LazyLock::new(|| {
 
 #[derive(Debug, Clone, Default)]
 pub struct AppsContext {
-    apps: HashMap<String, App>,
+    apps: HashMap<Option<String>, App>,
     processes: HashMap<i32, Process>,
-    processes_assigned_to_apps: HashSet<i32>,
-    read_bytes_from_dead_system_processes: u64,
-    write_bytes_from_dead_system_processes: u64,
-}
-
-/// Convenience struct for displaying running applications and
-/// displaying a "System Processes" item.
-#[derive(Debug, Clone)]
-pub struct AppItem {
-    pub id: Option<String>,
-    pub display_name: String,
-    pub icon: Icon,
-    pub description: Option<String>,
-    pub memory_usage: usize,
-    pub cpu_time_ratio: f32,
-    pub processes_amount: usize,
-    pub containerization: Containerization,
-    pub running_since: GString,
-    pub read_speed: f64,
-    pub read_total: u64,
-    pub write_speed: f64,
-    pub write_total: u64,
-    pub gpu_usage: f32,
-    pub enc_usage: f32,
-    pub dec_usage: f32,
-    pub gpu_mem_usage: u64,
 }
 
 /// Represents an application installed on the system. It doesn't
@@ -159,9 +133,10 @@ pub struct App {
     pub display_name: String,
     pub description: Option<String>,
     pub icon: Icon,
-    pub id: String,
+    pub id: Option<String>,
     pub read_bytes_from_dead_processes: u64,
     pub write_bytes_from_dead_processes: u64,
+    pub containerization: Containerization,
 }
 
 impl App {
@@ -180,7 +155,7 @@ impl App {
             applications_dir
         );
 
-        let apps: Vec<_> = applications_dir
+        let mut apps: Vec<_> = applications_dir
             .iter()
             .flat_map(|applications_path| {
                 applications_path.read_dir().ok().map(|read| {
@@ -200,6 +175,19 @@ impl App {
             "Detected {} apps within {elapsed:.2?}",
             applications_dir.len()
         );
+
+        apps.push(App {
+            processes: Vec::new(),
+            commandline: None,
+            executable_name: None,
+            display_name: i18n("System Processes"),
+            description: None,
+            icon: ThemedIcon::new("system-processes").into(),
+            id: None,
+            read_bytes_from_dead_processes: 0,
+            write_bytes_from_dead_processes: 0,
+            containerization: Containerization::None,
+        });
 
         apps
     }
@@ -229,6 +217,9 @@ impl App {
         }
 
         let exec = desktop_entry.get("Exec");
+        let is_flatpak = exec
+            .map(|exec| exec.starts_with("/usr/bin/flatpak --run"))
+            .unwrap_or_default();
         let commandline = exec
             .and_then(|exec| {
                 RE_ENV_FILTER
@@ -297,12 +288,24 @@ impl App {
             .or_else(|| desktop_entry.get("Comment"))
             .map(str::to_string);
 
+        let is_snap = desktop_entry.get("X-SnapInstanceName").is_some();
+
+        let containerization = if is_flatpak {
+            Containerization::Flatpak
+        } else if is_snap {
+            Containerization::Snap
+        } else {
+            Containerization::None
+        };
+
         debug!(
             "Found app \"{display_name}\" (ID: {id}) at {} with commandline `{}` (detected executable name: {})",
             file_path.to_string_lossy(),
             commandline.as_ref().unwrap_or(&"<None>".into()),
             executable_name.as_ref().unwrap_or(&"<None>".into()),
         );
+
+        let id = Some(id);
 
         Ok(App {
             processes: Vec::new(),
@@ -314,6 +317,7 @@ impl App {
             id,
             read_bytes_from_dead_processes: 0,
             write_bytes_from_dead_processes: 0,
+            containerization,
         })
     }
 
@@ -335,7 +339,7 @@ impl App {
     }
 
     pub fn processes_iter<'a>(&'a self, apps: &'a AppsContext) -> impl Iterator<Item = &Process> {
-        apps.all_processes()
+        apps.processes_iter()
             .filter(move |process| self.processes.contains(&process.data.pid))
     }
 
@@ -343,7 +347,7 @@ impl App {
         &'a mut self,
         apps: &'a mut AppsContext,
     ) -> impl Iterator<Item = &mut Process> {
-        apps.all_processes_mut()
+        apps.processes_iter_mut()
             .filter(move |process| self.processes.contains(&process.data.pid))
     }
 
@@ -428,6 +432,21 @@ impl App {
             .map(|process| process.execute_process_action(action))
             .collect()
     }
+
+    pub fn running_since(&self, apps: &AppsContext) -> GString {
+        boot_time()
+            .and_then(|boot_time| {
+                boot_time
+                    .add_seconds(self.starttime(apps))
+                    .context("unable to add seconds to boot time")
+            })
+            .and_then(|time| time.format("%c").context("unable to format running_since"))
+            .unwrap_or_else(|_| GString::from(i18n("N/A")))
+    }
+
+    pub fn running_processes(&self) -> usize {
+        self.processes.len()
+    }
 }
 
 impl AppsContext {
@@ -435,7 +454,7 @@ impl AppsContext {
     /// so try to do it only one time during the lifetime of the program.
     /// Please call refresh() immediately after this function.
     pub fn new() -> AppsContext {
-        let apps: HashMap<String, App> = App::all()
+        let apps: HashMap<Option<String>, App> = App::all()
             .into_iter()
             .map(|app| (app.id.clone(), app))
             .collect();
@@ -443,14 +462,11 @@ impl AppsContext {
         AppsContext {
             apps,
             processes: HashMap::new(),
-            processes_assigned_to_apps: HashSet::new(),
-            read_bytes_from_dead_system_processes: 0,
-            write_bytes_from_dead_system_processes: 0,
         }
     }
 
     pub fn gpu_fraction(&self, pci_slot: PciSlot) -> f32 {
-        self.all_processes()
+        self.processes_iter()
             .map(|process| {
                 (
                     &process.data.gpu_usage_stats,
@@ -488,7 +504,7 @@ impl AppsContext {
     }
 
     pub fn encoder_fraction(&self, pci_slot: PciSlot) -> f32 {
-        self.all_processes()
+        self.processes_iter()
             .map(|process| {
                 (
                     &process.data.gpu_usage_stats,
@@ -526,7 +542,7 @@ impl AppsContext {
     }
 
     pub fn decoder_fraction(&self, pci_slot: PciSlot) -> f32 {
-        self.all_processes()
+        self.processes_iter()
             .map(|process| {
                 (
                     &process.data.gpu_usage_stats,
@@ -568,27 +584,27 @@ impl AppsContext {
         // ↓ look for whether we can find an ID in the cgroup
         if let Some(app) = self
             .apps
-            .get(process.data.cgroup.as_deref().unwrap_or_default())
+            .get(&Some(process.data.cgroup.clone().unwrap_or_default()))
         {
             debug!(
                 "Associating process {} with app \"{}\" (ID: {}) based on process cgroup matching with app ID",
-                process.data.pid, app.display_name, app.id
+                process.data.pid, app.display_name, app.id.as_deref().unwrap_or_default()
             );
-            Some(app.id.clone())
-        } else if let Some(app) = self.apps.get(&process.executable_path) {
+            app.id.clone()
+        } else if let Some(app) = self.apps.get(&Some(process.executable_path.clone())) {
             // ↑ look for whether we can find an ID in the executable path of the process
             debug!(
                 "Associating process {} with app \"{}\" (ID: {}) based on process executable path matching with app ID",
-                process.data.pid, app.display_name, app.id
+                process.data.pid, app.display_name, app.id.as_deref().unwrap_or_default()
             );
-            Some(app.id.clone())
-        } else if let Some(app) = self.apps.get(&process.executable_name) {
+            app.id.clone()
+        } else if let Some(app) = self.apps.get(&Some(process.executable_name.clone())) {
             // ↑ look for whether we can find an ID in the executable name of the process
             debug!(
                 "Associating process {} with app \"{}\" (ID: {}) based on process executable name matching with app ID",
-                process.data.pid, app.display_name, app.id
+                process.data.pid, app.display_name, app.id.as_deref().unwrap_or_default()
             );
-            Some(app.id.clone())
+            app.id.clone()
         } else {
             self.apps
                 .values()
@@ -602,7 +618,7 @@ impl AppsContext {
                     {
                         debug!(
                             "Associating process {} with app \"{}\" (ID: {}) based on process executable pathmatching with app commandline ({})",
-                            process.data.pid, app.display_name, app.id, process.executable_path
+                            process.data.pid, app.display_name, app.id.as_deref().unwrap_or_default(), process.executable_path
                         );
                         true
                     } else if app
@@ -612,7 +628,7 @@ impl AppsContext {
                     {
                         debug!(
                             "Associating process {} with app \"{}\" (ID: {}) based on process executable name matching with app executable name ({})",
-                            process.data.pid, app.display_name, app.id, process.executable_name
+                            process.data.pid, app.display_name, app.id.as_deref().unwrap_or_default(), process.executable_name
                         );
                         true
                     } else if app
@@ -629,14 +645,14 @@ impl AppsContext {
                     {
                         debug!(
                             "Associating process {} with app \"{}\" (ID: {}) based on match in KNOWN_EXECUTABLE_NAME_EXCEPTIONS",
-                            process.data.pid, app.display_name, app.id
+                            process.data.pid, app.display_name, app.id.as_deref().unwrap_or_default()
                         );
                         true
                     } else {
                         false
                     }
                 })
-                .map(|app| app.id.clone())
+                .and_then(|app| app.id.clone())
         }
     }
 
@@ -644,24 +660,24 @@ impl AppsContext {
         self.processes.get(&pid)
     }
 
-    pub fn get_app(&self, id: &str) -> Option<&App> {
+    pub fn get_app(&self, id: &Option<String>) -> Option<&App> {
         self.apps.get(id)
     }
 
     #[must_use]
-    pub fn all_processes(&self) -> impl Iterator<Item = &Process> {
+    pub fn processes_iter(&self) -> impl Iterator<Item = &Process> {
         self.processes.values()
     }
 
     #[must_use]
-    pub fn all_processes_mut(&mut self) -> impl Iterator<Item = &mut Process> {
+    pub fn processes_iter_mut(&mut self) -> impl Iterator<Item = &mut Process> {
         self.processes.values_mut()
     }
 
     /// Returns a `HashMap` of running processes. For more info, refer to
     /// `ProcessItem`.
     pub fn process_items(&self) -> HashMap<i32, ProcessItem> {
-        self.all_processes()
+        self.processes_iter()
             .map(|process| (process.data.pid, self.process_item(process.data.pid)))
             .filter_map(|(pid, process_opt)| process_opt.map(|process| (pid, process)))
             .collect()
@@ -700,157 +716,19 @@ impl AppsContext {
         })
     }
 
-    /// Returns a `HashMap` of running graphical applications. For more info,
-    /// refer to `AppItem`.
-    #[must_use]
-    pub fn app_items(&self) -> HashMap<Option<String>, AppItem> {
-        let mut app_pids = HashSet::new();
+    pub fn apps_iter(&self) -> impl Iterator<Item = &App> {
+        self.apps.values()
+    }
 
-        let mut return_map = self
-            .apps
-            .iter()
-            .filter(|(_, app)| app.is_running() && !app.id.starts_with("xdg-desktop-portal"))
-            .map(|(_, app)| {
-                app.processes_iter(self).for_each(|process| {
-                    app_pids.insert(process.data.pid);
-                });
-
-                let is_flatpak = app
-                    .processes_iter(self)
-                    .filter(|process| {
-                        !process.data.commandline.starts_with("bwrap")
-                            && !process.data.commandline.is_empty()
-                    })
-                    .any(|process| process.data.containerization == Containerization::Flatpak);
-
-                let is_snap = app
-                    .processes_iter(self)
-                    .filter(|process| {
-                        !process.data.commandline.starts_with("bwrap")
-                            && !process.data.commandline.is_empty()
-                    })
-                    .any(|process| process.data.containerization == Containerization::Snap);
-
-                let containerization = if is_flatpak {
-                    Containerization::Flatpak
-                } else if is_snap {
-                    Containerization::Snap
-                } else {
-                    Containerization::None
-                };
-
-                let running_since = boot_time()
-                    .and_then(|boot_time| {
-                        boot_time
-                            .add_seconds(app.starttime(self))
-                            .context("unable to add seconds to boot time")
-                    })
-                    .and_then(|time| time.format("%c").context("unable to format running_since"))
-                    .unwrap_or_else(|_| GString::from(i18n("N/A")));
-
-                (
-                    Some(app.id.clone()),
-                    AppItem {
-                        id: Some(app.id.clone()),
-                        display_name: app.display_name.clone(),
-                        icon: app.icon.clone(),
-                        description: app.description.clone(),
-                        memory_usage: app.memory_usage(self),
-                        cpu_time_ratio: app.cpu_time_ratio(self),
-                        processes_amount: app.processes_iter(self).count(),
-                        containerization,
-                        running_since,
-                        read_speed: app.read_speed(self),
-                        read_total: app.read_total(self),
-                        write_speed: app.write_speed(self),
-                        write_total: app.write_total(self),
-                        gpu_usage: app.gpu_usage(self),
-                        enc_usage: app.enc_usage(self),
-                        dec_usage: app.dec_usage(self),
-                        gpu_mem_usage: app.gpu_mem_usage(self),
-                    },
-                )
-            })
-            .collect::<HashMap<Option<String>, AppItem>>();
-
-        let system_cpu_ratio = self
-            .system_processes_iter()
-            .map(Process::cpu_time_ratio)
-            .sum();
-
-        let system_memory_usage: usize = self
-            .system_processes_iter()
-            .map(|process| process.data.memory_usage)
-            .sum();
-
-        let system_read_speed = self
-            .system_processes_iter()
-            .filter_map(Process::read_speed)
-            .sum();
-
-        let system_read_total = self.read_bytes_from_dead_system_processes
-            + self
-                .system_processes_iter()
-                .filter_map(|process| process.data.read_bytes)
-                .sum::<u64>();
-
-        let system_write_speed = self
-            .system_processes_iter()
-            .filter_map(Process::write_speed)
-            .sum();
-
-        let system_write_total = self.write_bytes_from_dead_system_processes
-            + self
-                .system_processes_iter()
-                .filter_map(|process| process.data.write_bytes)
-                .sum::<u64>();
-
-        let system_gpu_usage = self.system_processes_iter().map(Process::gpu_usage).sum();
-
-        let system_enc_usage = self.system_processes_iter().map(Process::enc_usage).sum();
-
-        let system_dec_usage = self.system_processes_iter().map(Process::dec_usage).sum();
-
-        let system_gpu_mem_usage = self
-            .system_processes_iter()
-            .map(Process::gpu_mem_usage)
-            .sum();
-
-        let system_running_since = boot_time()
-            .and_then(|boot_time| {
-                boot_time
-                    .format("%c")
-                    .context("unable to format running_time")
-            })
-            .unwrap_or_else(|_| GString::from(i18n("N/A")));
-
-        return_map.insert(
-            None,
-            AppItem {
-                id: None,
-                display_name: i18n("System Processes"),
-                icon: ThemedIcon::new("system-processes").into(),
-                description: None,
-                memory_usage: system_memory_usage,
-                cpu_time_ratio: system_cpu_ratio,
-                processes_amount: self
-                    .processes
-                    .len()
-                    .saturating_sub(self.processes_assigned_to_apps.len()),
-                containerization: Containerization::None,
-                running_since: system_running_since,
-                read_speed: system_read_speed,
-                read_total: system_read_total,
-                write_speed: system_write_speed,
-                write_total: system_write_total,
-                gpu_usage: system_gpu_usage,
-                enc_usage: system_enc_usage,
-                dec_usage: system_dec_usage,
-                gpu_mem_usage: system_gpu_mem_usage,
-            },
-        );
-
-        return_map
+    pub fn running_apps_iter(&self) -> impl Iterator<Item = &App> {
+        self.apps_iter().filter(|app| {
+            app.is_running()
+                && !app
+                    .id
+                    .as_ref()
+                    .map(|id| id.starts_with("xdg-desktop-portal"))
+                    .unwrap_or_default()
+        })
     }
 
     /// Refreshes the statistics about the running applications and processes.
@@ -876,13 +754,10 @@ impl AppsContext {
 
                 let mut new_process = Process::from_process_data(process_data);
 
-                if let Some(app_id) = self.app_associated_with_process(&new_process) {
-                    self.processes_assigned_to_apps.insert(new_process.data.pid);
-                    self.apps
-                        .get_mut(&app_id)
-                        .unwrap()
-                        .add_process(&mut new_process);
-                }
+                self.apps
+                    .get_mut(&self.app_associated_with_process(&new_process))
+                    .unwrap()
+                    .add_process(&mut new_process);
 
                 self.processes.insert(new_process.data.pid, new_process);
             }
@@ -920,7 +795,7 @@ impl AppsContext {
         });
 
         // same as above but for system processes
-        let (read_dead, write_dead) = self
+        /*let (read_dead, write_dead) = self
             .processes
             .iter()
             .filter(|(pid, _)| {
@@ -944,11 +819,6 @@ impl AppsContext {
 
         // remove the dead process from out list of app processes
         self.processes_assigned_to_apps
-            .retain(|pid| updated_processes.contains(pid));
-    }
-
-    pub fn system_processes_iter(&self) -> impl Iterator<Item = &Process> {
-        self.all_processes()
-            .filter(|process| !self.processes_assigned_to_apps.contains(&process.data.pid))
+            .retain(|pid| updated_processes.contains(pid));*/
     }
 }

--- a/src/utils/app.rs
+++ b/src/utils/app.rs
@@ -219,7 +219,7 @@ impl App {
 
         let exec = desktop_entry.get("Exec");
         let is_flatpak = exec
-            .map(|exec| exec.starts_with("/usr/bin/flatpak --run"))
+            .map(|exec| exec.starts_with("/usr/bin/flatpak run"))
             .unwrap_or_default();
         let commandline = exec
             .and_then(|exec| {
@@ -292,19 +292,30 @@ impl App {
         let is_snap = desktop_entry.get("X-SnapInstanceName").is_some();
 
         let containerization = if is_flatpak {
+            debug!(
+                "Found Flatpak app \"{display_name}\" (ID: {id}) at {} with commandline `{}` (detected executable name: {})",
+                file_path.to_string_lossy(),
+                commandline.as_ref().unwrap_or(&"<None>".into()),
+                executable_name.as_ref().unwrap_or(&"<None>".into()),
+            );
             Containerization::Flatpak
         } else if is_snap {
+            debug!(
+                "Found Snap app \"{display_name}\" (ID: {id}) at {} with commandline `{}` (detected executable name: {})",
+                file_path.to_string_lossy(),
+                commandline.as_ref().unwrap_or(&"<None>".into()),
+                executable_name.as_ref().unwrap_or(&"<None>".into()),
+            );
             Containerization::Snap
         } else {
+            debug!(
+                "Found native app \"{display_name}\" (ID: {id}) at {} with commandline `{}` (detected executable name: {})",
+                file_path.to_string_lossy(),
+                commandline.as_ref().unwrap_or(&"<None>".into()),
+                executable_name.as_ref().unwrap_or(&"<None>".into()),
+            );
             Containerization::None
         };
-
-        debug!(
-            "Found app \"{display_name}\" (ID: {id}) at {} with commandline `{}` (detected executable name: {})",
-            file_path.to_string_lossy(),
-            commandline.as_ref().unwrap_or(&"<None>".into()),
-            executable_name.as_ref().unwrap_or(&"<None>".into()),
-        );
 
         let id = Some(id);
 

--- a/src/utils/gpu/amd.rs
+++ b/src/utils/gpu/amd.rs
@@ -1,10 +1,9 @@
 use anyhow::{bail, Result};
-use hashbrown::HashMap;
 use log::{debug, warn};
 use process_data::pci_slot::PciSlot;
 use regex::Regex;
 
-use std::{path::PathBuf, sync::LazyLock, time::Instant};
+use std::{collections::HashMap, path::PathBuf, sync::LazyLock, time::Instant};
 
 use crate::utils::{
     pci::{self, Device},

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -40,11 +40,11 @@ static BOOT_TIMESTAMP: LazyLock<Option<i64>> = LazyLock::new(|| {
         .ok()
 });
 
-static TICK_RATE: LazyLock<usize> =
-    LazyLock::new(|| sysconf::sysconf(sysconf::SysconfVariable::ScClkTck).unwrap_or(100) as usize);
-
 static FLATPAK_APP_PATH: LazyLock<String> =
     LazyLock::new(|| flatpak_app_path().unwrap_or_else(|_| String::new()));
+
+pub static TICK_RATE: LazyLock<usize> =
+    LazyLock::new(|| sysconf::sysconf(sysconf::SysconfVariable::ScClkTck).unwrap_or(100) as usize);
 
 pub static NUM_CPUS: LazyLock<usize> = LazyLock::new(num_cpus::get);
 

--- a/src/utils/pci.rs
+++ b/src/utils/pci.rs
@@ -93,6 +93,8 @@ fn parse_pci_ids() -> Result<BTreeMap<u16, Vendor>> {
 
     let mut seen: BTreeMap<u16, Vendor> = BTreeMap::new();
 
+    let (mut vendors_count, mut devices_count, mut subdevices_count) = (0, 0, 0);
+
     for line in reader.lines().map_while(Result::ok) {
         if line.starts_with('C') {
             // case 1: we've reached the classes, time to stop
@@ -130,6 +132,8 @@ fn parse_pci_ids() -> Result<BTreeMap<u16, Vendor>> {
                 name,
             };
 
+            subdevices_count += 1;
+
             seen.values_mut()
                 .last()
                 .and_then(|vendor| vendor.devices.values_mut().last())
@@ -164,6 +168,8 @@ fn parse_pci_ids() -> Result<BTreeMap<u16, Vendor>> {
                 sub_devices: Vec::new(),
             };
 
+            devices_count += 1;
+
             seen.values_mut()
                 .last()
                 .with_context(|| format!("no preceding device (line: {line})"))?
@@ -191,13 +197,15 @@ fn parse_pci_ids() -> Result<BTreeMap<u16, Vendor>> {
                 devices: BTreeMap::new(),
             };
 
+            vendors_count += 1;
+
             seen.insert(vid, vendor);
         }
     }
 
     let elapsed = start.elapsed();
 
-    info!("Successfully parsed pci.ids within {elapsed:.2?}");
+    info!("Successfully parsed pci.ids within {elapsed:.2?} (vendors: {vendors_count}, devices: {devices_count}, subdevices: {subdevices_count})");
 
     Ok(seen)
 }

--- a/src/utils/process.rs
+++ b/src/utils/process.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Context, Result};
 use config::LIBEXECDIR;
 use log::debug;
-use process_data::{pci_slot::PciSlot, Containerization, GpuUsageStats, ProcessData};
+use process_data::{pci_slot::PciSlot, GpuUsageStats, ProcessData};
 use std::{
     collections::BTreeMap,
     io::{Read, Write},
@@ -10,11 +10,16 @@ use std::{
 };
 use strum_macros::Display;
 
-use gtk::gio::{Icon, ThemedIcon};
+use gtk::{
+    gio::{Icon, ThemedIcon},
+    glib::GString,
+};
 
 use crate::config;
 
-use super::{NaNDefault, FLATPAK_APP_PATH, FLATPAK_SPAWN, IS_FLATPAK, NUM_CPUS, TICK_RATE};
+use super::{
+    boot_time, NaNDefault, FLATPAK_APP_PATH, FLATPAK_SPAWN, IS_FLATPAK, NUM_CPUS, TICK_RATE,
+};
 
 static OTHER_PROCESS: LazyLock<Mutex<(ChildStdin, ChildStdout)>> = LazyLock::new(|| {
     let proxy_path = if *IS_FLATPAK {
@@ -72,30 +77,6 @@ pub enum ProcessAction {
     STOP,
     KILL,
     CONT,
-}
-/// Convenience struct for displaying running processes
-#[derive(Debug, Clone)]
-pub struct ProcessItem {
-    pub pid: i32,
-    pub user: String,
-    pub display_name: String,
-    pub icon: Icon,
-    pub memory_usage: usize,
-    pub cpu_time_ratio: f32,
-    pub user_cpu_time: f64,
-    pub system_cpu_time: f64,
-    pub commandline: String,
-    pub containerization: Containerization,
-    pub starttime: f64,
-    pub cgroup: Option<String>,
-    pub read_speed: Option<f64>,
-    pub read_total: Option<u64>,
-    pub write_speed: Option<f64>,
-    pub write_total: Option<u64>,
-    pub gpu_usage: f32,
-    pub enc_usage: f32,
-    pub dec_usage: f32,
-    pub gpu_mem_usage: u64,
 }
 
 impl Process {
@@ -414,6 +395,16 @@ impl Process {
     #[must_use]
     pub fn starttime(&self) -> f64 {
         self.data.starttime as f64 / *TICK_RATE as f64
+    }
+
+    pub fn running_since(&self) -> Result<GString> {
+        boot_time()
+            .and_then(|boot_time| {
+                boot_time
+                    .add_seconds(self.starttime())
+                    .context("unable to add seconds to boot time")
+            })
+            .and_then(|time| time.format("%c").context("unable to format running_since"))
     }
 
     pub fn sanitize_cmdline<S: AsRef<str>>(cmdline: S) -> Option<String> {


### PR DESCRIPTION
- Remove `ProcessItem` and `AppItem` abstraction layer
- Use teardown methods for column factories to hopefully actually free list rows of dead processes/apps
- Flatpak: Put /usr/local/share into XDG_DATA_DIRS