### PR TITLE
Update Ukrainian translation

### DIFF
--- a/po/uk.po
+++ b/po/uk.po
@@ -5,8 +5,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: resources\n"
 "Report-Msgid-Bugs-To: https://github.com/nokyan/resources/issues\n"
-"POT-Creation-Date: 2024-07-07 18:21+0200\n"
-"PO-Revision-Date: 2024-07-29 20:57+0300\n"
+"POT-Creation-Date: 2024-08-09 19:44+0200\n"
+"PO-Revision-Date: 2024-08-09 23:54+0300\n"
 "Last-Translator: volkov <volkovissocool@gmail.com>\n"
 "Language-Team: volkov <volkovissocool@gmail.com>\n"
 "Language: uk\n"
@@ -18,7 +18,7 @@ msgstr ""
 "X-Generator: Poedit 3.4.4\n"
 
 #: data/net.nokyan.Resources.desktop.in.in:3
-#: data/net.nokyan.Resources.metainfo.xml.in.in:4 src/application.rs:191
+#: data/net.nokyan.Resources.metainfo.xml.in.in:4 src/application.rs:262
 msgid "Resources"
 msgstr "Ресурси"
 
@@ -56,28 +56,28 @@ msgid "CPU"
 msgstr "Процесору"
 
 #: data/net.nokyan.Resources.metainfo.xml.in.in:25
-#: src/ui/pages/applications/mod.rs:670 src/ui/pages/memory.rs:132
-#: src/ui/pages/memory.rs:205 src/ui/pages/processes/mod.rs:726
+#: src/ui/pages/applications/mod.rs:816 src/ui/pages/memory.rs:138
+#: src/ui/pages/memory.rs:219 src/ui/pages/processes/mod.rs:964
 #: data/resources/ui/window.ui:158 data/resources/ui/window.ui:165
-#: data/resources/ui/dialogs/app_dialog.ui:86
-#: data/resources/ui/dialogs/process_dialog.ui:68
+#: data/resources/ui/dialogs/app_dialog.ui:82
+#: data/resources/ui/dialogs/process_dialog.ui:64
 #: data/resources/ui/dialogs/settings_dialog.ui:133
-#: data/resources/ui/dialogs/settings_dialog.ui:204
+#: data/resources/ui/dialogs/settings_dialog.ui:215
 msgid "Memory"
 msgstr "Оперативна пам'ять"
 
 #: data/net.nokyan.Resources.metainfo.xml.in.in:26
-#: src/ui/pages/applications/mod.rs:965 src/ui/pages/gpu.rs:146
-#: src/ui/pages/processes/mod.rs:1032 src/ui/window.rs:286
-#: data/resources/ui/dialogs/app_dialog.ui:135
-#: data/resources/ui/dialogs/process_dialog.ui:113
+#: src/ui/pages/applications/mod.rs:1189 src/ui/pages/gpu.rs:155
+#: src/ui/pages/processes/mod.rs:1348 src/ui/window.rs:302
+#: data/resources/ui/dialogs/app_dialog.ui:131
+#: data/resources/ui/dialogs/process_dialog.ui:109
 #: data/resources/ui/dialogs/settings_dialog.ui:163
-#: data/resources/ui/dialogs/settings_dialog.ui:234
+#: data/resources/ui/dialogs/settings_dialog.ui:245
 msgid "GPU"
 msgstr "Відеокарта"
 
 #: data/net.nokyan.Resources.metainfo.xml.in.in:27
-#: data/resources/ui/dialogs/settings_dialog.ui:288
+#: data/resources/ui/dialogs/settings_dialog.ui:304
 msgid "Network Interfaces"
 msgstr "Мережевих інтерфейсів"
 
@@ -85,178 +85,187 @@ msgstr "Мережевих інтерфейсів"
 msgid "Storage Devices"
 msgstr "Накопичувачів даних"
 
-#: src/application.rs:193
+#: src/application.rs:264
 msgid "The Nalux Team"
 msgstr "Команда Nalux"
 
-#: src/application.rs:201
+#: src/application.rs:272
 msgid "Report Issues"
 msgstr "Повідомити про проблеми"
 
 #. Translator credits. Replace "translator-credits" with your name/username, and optionally an email or URL.
 #. One name per line, please do not remove previous names.
-#: src/application.rs:207
+#: src/application.rs:278
 msgid "translator-credits"
 msgstr "volkov <volkovissocool@gmail.com>"
 
-#: src/application.rs:208
+#: src/application.rs:279
 msgid "Icon by"
 msgstr "Піктограму зробив"
 
-#: src/ui/dialogs/app_dialog.rs:145 src/ui/dialogs/process_dialog.rs:140
-#: src/ui/pages/drive.rs:418 src/ui/pages/drive.rs:428
-msgid "No"
-msgstr "Ні"
-
-#: src/ui/dialogs/app_dialog.rs:146 src/ui/dialogs/process_dialog.rs:141
-msgid "Yes (Flatpak)"
-msgstr "Так (Flatpak)"
-
-#: src/ui/dialogs/app_dialog.rs:147 src/ui/dialogs/process_dialog.rs:142
-msgid "Yes (Snap)"
-msgstr "Так (Snap)"
-
-#: src/ui/dialogs/process_dialog.rs:128 src/ui/dialogs/process_dialog.rs:135
-#: src/ui/dialogs/process_dialog.rs:137 src/ui/dialogs/process_dialog.rs:162
-#: src/ui/dialogs/process_dialog.rs:169 src/ui/dialogs/process_dialog.rs:176
-#: src/ui/dialogs/process_dialog.rs:183 src/ui/pages/applications/mod.rs:784
-#: src/ui/pages/applications/mod.rs:882 src/ui/pages/battery.rs:223
-#: src/ui/pages/battery.rs:244 src/ui/pages/battery.rs:250
-#: src/ui/pages/battery.rs:253 src/ui/pages/battery.rs:279
-#: src/ui/pages/battery.rs:303 src/ui/pages/battery.rs:305
-#: src/ui/pages/battery.rs:315 src/ui/pages/cpu.rs:237 src/ui/pages/cpu.rs:252
-#: src/ui/pages/cpu.rs:266 src/ui/pages/cpu.rs:272 src/ui/pages/cpu.rs:278
-#: src/ui/pages/cpu.rs:284 src/ui/pages/cpu.rs:288 src/ui/pages/cpu.rs:291
-#: src/ui/pages/cpu.rs:384 src/ui/pages/drive.rs:325 src/ui/pages/drive.rs:355
-#: src/ui/pages/drive.rs:357 src/ui/pages/drive.rs:385
-#: src/ui/pages/drive.rs:387 src/ui/pages/drive.rs:403
-#: src/ui/pages/drive.rs:404 src/ui/pages/drive.rs:411
-#: src/ui/pages/drive.rs:421 src/ui/pages/drive.rs:431 src/ui/pages/gpu.rs:251
-#: src/ui/pages/gpu.rs:293 src/ui/pages/gpu.rs:318 src/ui/pages/gpu.rs:321
-#: src/ui/pages/gpu.rs:332 src/ui/pages/gpu.rs:352 src/ui/pages/gpu.rs:364
-#: src/ui/pages/gpu.rs:378 src/ui/pages/gpu.rs:380 src/ui/pages/gpu.rs:392
-#: src/ui/pages/gpu.rs:399 src/ui/pages/gpu.rs:403 src/ui/pages/memory.rs:240
-#: src/ui/pages/memory.rs:241 src/ui/pages/memory.rs:245
-#: src/ui/pages/memory.rs:246 src/ui/pages/memory.rs:250
-#: src/ui/pages/memory.rs:251 src/ui/pages/memory.rs:279
-#: src/ui/pages/memory.rs:333 src/ui/pages/network.rs:257
-#: src/ui/pages/network.rs:264 src/ui/pages/network.rs:271
-#: src/ui/pages/network.rs:277 src/ui/pages/network.rs:280
-#: src/ui/pages/network.rs:341 src/ui/pages/network.rs:344
-#: src/ui/pages/network.rs:346 src/ui/pages/network.rs:375
-#: src/ui/pages/network.rs:378 src/ui/pages/network.rs:380
-#: src/ui/pages/processes/mod.rs:839 src/ui/pages/processes/mod.rs:892
-#: src/ui/pages/processes/mod.rs:945 src/ui/pages/processes/mod.rs:998
-#: src/utils/app.rs:689 src/utils/app.rs:765 src/utils/battery.rs:144
-#: src/utils/drive.rs:90 src/utils/gpu/mod.rs:258 src/utils/gpu/mod.rs:264
+#: src/ui/dialogs/app_dialog.rs:146 src/ui/dialogs/process_dialog.rs:125
+#: src/ui/dialogs/process_dialog.rs:133 src/ui/dialogs/process_dialog.rs:135
+#: src/ui/dialogs/process_dialog.rs:153 src/ui/dialogs/process_dialog.rs:160
+#: src/ui/dialogs/process_dialog.rs:167 src/ui/dialogs/process_dialog.rs:174
+#: src/ui/pages/applications/mod.rs:959 src/ui/pages/applications/mod.rs:1083
+#: src/ui/pages/battery.rs:238 src/ui/pages/battery.rs:258
+#: src/ui/pages/battery.rs:264 src/ui/pages/battery.rs:267
+#: src/ui/pages/battery.rs:293 src/ui/pages/battery.rs:317
+#: src/ui/pages/battery.rs:319 src/ui/pages/battery.rs:329
+#: src/ui/pages/cpu.rs:251 src/ui/pages/cpu.rs:266 src/ui/pages/cpu.rs:281
+#: src/ui/pages/cpu.rs:287 src/ui/pages/cpu.rs:293 src/ui/pages/cpu.rs:299
+#: src/ui/pages/cpu.rs:303 src/ui/pages/cpu.rs:306 src/ui/pages/cpu.rs:403
+#: src/ui/pages/drive.rs:340 src/ui/pages/drive.rs:370
+#: src/ui/pages/drive.rs:372 src/ui/pages/drive.rs:400
+#: src/ui/pages/drive.rs:402 src/ui/pages/drive.rs:418
+#: src/ui/pages/drive.rs:419 src/ui/pages/drive.rs:426
+#: src/ui/pages/drive.rs:436 src/ui/pages/drive.rs:446 src/ui/pages/gpu.rs:269
+#: src/ui/pages/gpu.rs:311 src/ui/pages/gpu.rs:336 src/ui/pages/gpu.rs:339
+#: src/ui/pages/gpu.rs:350 src/ui/pages/gpu.rs:370 src/ui/pages/gpu.rs:382
+#: src/ui/pages/gpu.rs:396 src/ui/pages/gpu.rs:398 src/ui/pages/gpu.rs:410
+#: src/ui/pages/gpu.rs:417 src/ui/pages/gpu.rs:421 src/ui/pages/memory.rs:254
+#: src/ui/pages/memory.rs:255 src/ui/pages/memory.rs:259
+#: src/ui/pages/memory.rs:260 src/ui/pages/memory.rs:264
+#: src/ui/pages/memory.rs:265 src/ui/pages/memory.rs:293
+#: src/ui/pages/memory.rs:350 src/ui/pages/network.rs:272
+#: src/ui/pages/network.rs:279 src/ui/pages/network.rs:286
+#: src/ui/pages/network.rs:292 src/ui/pages/network.rs:295
+#: src/ui/pages/network.rs:356 src/ui/pages/network.rs:359
+#: src/ui/pages/network.rs:361 src/ui/pages/network.rs:390
+#: src/ui/pages/network.rs:393 src/ui/pages/network.rs:395
+#: src/ui/pages/processes/mod.rs:1106 src/ui/pages/processes/mod.rs:1172
+#: src/ui/pages/processes/mod.rs:1238 src/ui/pages/processes/mod.rs:1304
+#: src/ui/pages/processes/mod.rs:1786 src/ui/pages/processes/mod.rs:1788
+#: src/utils/battery.rs:139 src/utils/drive.rs:90 src/utils/gpu/mod.rs:258
+#: src/utils/gpu/mod.rs:264
 msgid "N/A"
 msgstr "Невідомо"
 
-#: src/ui/pages/applications/mod.rs:153 data/resources/ui/window.ui:65
+#: src/ui/dialogs/process_options_dialog.rs:142 src/ui/pages/cpu.rs:265
+#: src/ui/pages/cpu.rs:387 src/ui/pages/cpu.rs:391
+msgid "CPU {}"
+msgstr "Процесор {}"
+
+#: src/ui/pages/applications/application_entry.rs:179 src/ui/pages/drive.rs:433
+#: src/ui/pages/drive.rs:443 src/ui/pages/processes/process_entry.rs:206
+msgid "No"
+msgstr "Ні"
+
+#: src/ui/pages/applications/application_entry.rs:180
+#: src/ui/pages/processes/process_entry.rs:207
+msgid "Yes (Flatpak)"
+msgstr "Так (Flatpak)"
+
+#: src/ui/pages/applications/application_entry.rs:181
+#: src/ui/pages/processes/process_entry.rs:208
+msgid "Yes (Snap)"
+msgstr "Так (Snap)"
+
+#: src/ui/pages/applications/mod.rs:163 data/resources/ui/window.ui:65
 #: data/resources/ui/window.ui:72
 #: data/resources/ui/dialogs/settings_dialog.ui:127
 msgid "Apps"
 msgstr "Додатки"
 
-#: src/ui/pages/applications/mod.rs:571
+#: src/ui/pages/applications/mod.rs:674
 msgid "Running Apps: {}"
 msgstr "Запущених додатків: {}"
 
-#: src/ui/pages/applications/mod.rs:597 src/ui/pages/processes/mod.rs:572
+#: src/ui/pages/applications/mod.rs:713 src/ui/pages/processes/mod.rs:749
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: src/ui/pages/applications/mod.rs:624
+#: src/ui/pages/applications/mod.rs:759
 msgid "App"
 msgstr "Додаток"
 
-#: src/ui/pages/applications/mod.rs:716 src/ui/pages/cpu.rs:149
-#: src/ui/pages/processes/mod.rs:771 src/ui/window.rs:332
+#: src/ui/pages/applications/mod.rs:875 src/ui/pages/cpu.rs:155
+#: src/ui/pages/processes/mod.rs:1022 src/ui/window.rs:348
 #: data/resources/ui/window.ui:127 data/resources/ui/window.ui:134
-#: data/resources/ui/dialogs/app_dialog.ui:77
-#: data/resources/ui/dialogs/process_dialog.ui:59
+#: data/resources/ui/dialogs/app_dialog.ui:73
+#: data/resources/ui/dialogs/process_dialog.ui:55
 #: data/resources/ui/dialogs/settings_dialog.ui:138
-#: data/resources/ui/dialogs/settings_dialog.ui:209
+#: data/resources/ui/dialogs/settings_dialog.ui:220
 msgid "Processor"
 msgstr "Процесор"
 
-#: src/ui/pages/applications/mod.rs:766 src/ui/pages/processes/mod.rs:821
-#: data/resources/ui/dialogs/app_dialog.ui:95
-#: data/resources/ui/dialogs/process_dialog.ui:73
+#: src/ui/pages/applications/mod.rs:938 src/ui/pages/processes/mod.rs:1085
+#: data/resources/ui/dialogs/app_dialog.ui:91
+#: data/resources/ui/dialogs/process_dialog.ui:69
 #: data/resources/ui/dialogs/settings_dialog.ui:143
-#: data/resources/ui/dialogs/settings_dialog.ui:214
+#: data/resources/ui/dialogs/settings_dialog.ui:225
 msgid "Drive Read"
 msgstr "Читання з диска"
 
-#: src/ui/pages/applications/mod.rs:817 src/ui/pages/processes/mod.rs:874
-#: data/resources/ui/dialogs/app_dialog.ui:104
-#: data/resources/ui/dialogs/process_dialog.ui:82
+#: src/ui/pages/applications/mod.rs:1002 src/ui/pages/processes/mod.rs:1151
+#: data/resources/ui/dialogs/app_dialog.ui:100
+#: data/resources/ui/dialogs/process_dialog.ui:78
 #: data/resources/ui/dialogs/settings_dialog.ui:148
-#: data/resources/ui/dialogs/settings_dialog.ui:219
+#: data/resources/ui/dialogs/settings_dialog.ui:230
 msgid "Drive Read Total"
 msgstr "Читання з диска (загалом)"
 
-#: src/ui/pages/applications/mod.rs:864 src/ui/pages/processes/mod.rs:927
-#: data/resources/ui/dialogs/app_dialog.ui:113
-#: data/resources/ui/dialogs/process_dialog.ui:91
+#: src/ui/pages/applications/mod.rs:1062 src/ui/pages/processes/mod.rs:1217
+#: data/resources/ui/dialogs/app_dialog.ui:109
+#: data/resources/ui/dialogs/process_dialog.ui:87
 #: data/resources/ui/dialogs/settings_dialog.ui:153
-#: data/resources/ui/dialogs/settings_dialog.ui:224
+#: data/resources/ui/dialogs/settings_dialog.ui:235
 msgid "Drive Write"
 msgstr "Запис на диск"
 
-#: src/ui/pages/applications/mod.rs:917 src/ui/pages/processes/mod.rs:980
-#: data/resources/ui/dialogs/app_dialog.ui:122
-#: data/resources/ui/dialogs/process_dialog.ui:100
+#: src/ui/pages/applications/mod.rs:1128 src/ui/pages/processes/mod.rs:1283
+#: data/resources/ui/dialogs/app_dialog.ui:118
+#: data/resources/ui/dialogs/process_dialog.ui:96
 #: data/resources/ui/dialogs/settings_dialog.ui:158
-#: data/resources/ui/dialogs/settings_dialog.ui:229
+#: data/resources/ui/dialogs/settings_dialog.ui:240
 msgid "Drive Write Total"
 msgstr "Запис на диск (загалом)"
 
-#: src/ui/pages/applications/mod.rs:1010 src/ui/pages/processes/mod.rs:1077
-#: data/resources/ui/dialogs/app_dialog.ui:153
-#: data/resources/ui/dialogs/process_dialog.ui:131
+#: src/ui/pages/applications/mod.rs:1247 src/ui/pages/processes/mod.rs:1406
+#: data/resources/ui/dialogs/app_dialog.ui:149
+#: data/resources/ui/dialogs/process_dialog.ui:127
 #: data/resources/ui/dialogs/settings_dialog.ui:173
-#: data/resources/ui/dialogs/settings_dialog.ui:244
+#: data/resources/ui/dialogs/settings_dialog.ui:255
 msgid "Video Encoder"
 msgstr "Відео кодувальник"
 
-#: src/ui/pages/applications/mod.rs:1057 src/ui/pages/processes/mod.rs:1124
-#: data/resources/ui/dialogs/app_dialog.ui:162
-#: data/resources/ui/dialogs/process_dialog.ui:140
+#: src/ui/pages/applications/mod.rs:1307 src/ui/pages/processes/mod.rs:1466
+#: data/resources/ui/dialogs/app_dialog.ui:158
+#: data/resources/ui/dialogs/process_dialog.ui:136
 #: data/resources/ui/dialogs/settings_dialog.ui:178
-#: data/resources/ui/dialogs/settings_dialog.ui:249
+#: data/resources/ui/dialogs/settings_dialog.ui:260
 msgid "Video Decoder"
 msgstr "Відео декодувальник"
 
-#: src/ui/pages/applications/mod.rs:1103 src/ui/pages/processes/mod.rs:1171
-#: data/resources/ui/dialogs/app_dialog.ui:144
-#: data/resources/ui/dialogs/process_dialog.ui:122
+#: src/ui/pages/applications/mod.rs:1366 src/ui/pages/processes/mod.rs:1526
+#: data/resources/ui/dialogs/app_dialog.ui:140
+#: data/resources/ui/dialogs/process_dialog.ui:118
 #: data/resources/ui/dialogs/settings_dialog.ui:168
-#: data/resources/ui/dialogs/settings_dialog.ui:239
+#: data/resources/ui/dialogs/settings_dialog.ui:250
 msgid "Video Memory"
 msgstr "Відеопам'ять"
 
-#: src/ui/pages/applications/mod.rs:1147 src/ui/pages/processes/mod.rs:1354
+#: src/ui/pages/applications/mod.rs:1423 src/ui/pages/processes/mod.rs:1828
 msgid "End {}?"
 msgstr "Завершити {}?"
 
-#: src/ui/pages/applications/mod.rs:1148 src/ui/pages/processes/mod.rs:1355
+#: src/ui/pages/applications/mod.rs:1424 src/ui/pages/processes/mod.rs:1829
 msgid "Halt {}?"
 msgstr "Зупинити {}?"
 
-#: src/ui/pages/applications/mod.rs:1149 src/ui/pages/processes/mod.rs:1356
+#: src/ui/pages/applications/mod.rs:1425 src/ui/pages/processes/mod.rs:1830
 msgid "Kill {}?"
 msgstr "Знищити {}?"
 
-#: src/ui/pages/applications/mod.rs:1150 src/ui/pages/processes/mod.rs:1357
+#: src/ui/pages/applications/mod.rs:1426 src/ui/pages/processes/mod.rs:1831
 msgid "Continue {}?"
 msgstr "Продовжити {}?"
 
-#: src/ui/pages/applications/mod.rs:1156 src/ui/pages/processes/mod.rs:1363
+#: src/ui/pages/applications/mod.rs:1432 src/ui/pages/processes/mod.rs:1837
 msgid "Unsaved work might be lost."
 msgstr "Не збережена робота може бути втрачена."
 
-#: src/ui/pages/applications/mod.rs:1157
+#: src/ui/pages/applications/mod.rs:1433
 msgid ""
 "Halting an app can come with serious risks such as losing data and security "
 "implications. Use with caution."
@@ -264,7 +273,7 @@ msgstr ""
 "Зупинка додатку може призвести до серйозних ризиків, такі як: втрата даних і "
 "проблеми з безпекою. Продовжуйте на свій власний ризик."
 
-#: src/ui/pages/applications/mod.rs:1158
+#: src/ui/pages/applications/mod.rs:1434
 msgid ""
 "Killing an app can come with serious risks such as losing data and security "
 "implications. Use with caution."
@@ -272,175 +281,181 @@ msgstr ""
 "Знищення додатку може призвести до серйозних ризиків, такі як: втрата даних "
 "і проблеми з безпекою. Продовжуйте на свій власний ризик."
 
-#: src/ui/pages/applications/mod.rs:1165
-#: data/resources/ui/pages/applications.ui:97
+#: src/ui/pages/applications/mod.rs:1441
+#: data/resources/ui/pages/applications.ui:22
+#: data/resources/ui/pages/applications.ui:127
 msgid "End App"
 msgstr "Завершити додаток"
 
-#: src/ui/pages/applications/mod.rs:1166
+#: src/ui/pages/applications/mod.rs:1442
 #: data/resources/ui/pages/applications.ui:10
+#: data/resources/ui/pages/applications.ui:30
 msgid "Halt App"
 msgstr "Зупинити додаток"
 
-#: src/ui/pages/applications/mod.rs:1167
+#: src/ui/pages/applications/mod.rs:1443
 #: data/resources/ui/pages/applications.ui:6
+#: data/resources/ui/pages/applications.ui:26
 msgid "Kill App"
 msgstr "Знищити додаток"
 
-#: src/ui/pages/applications/mod.rs:1168
+#: src/ui/pages/applications/mod.rs:1444
 #: data/resources/ui/pages/applications.ui:14
+#: data/resources/ui/pages/applications.ui:34
 msgid "Continue App"
 msgstr "Продовжити додаток"
 
-#: src/ui/pages/battery.rs:136 src/ui/pages/drive.rs:157
+#: src/ui/pages/battery.rs:142 src/ui/pages/drive.rs:163
 msgid "Drive"
 msgstr "Накопичувач"
 
-#: src/ui/pages/battery.rs:228
+#: src/ui/pages/battery.rs:243
 msgid "Battery Charge"
 msgstr "Заряд батареї"
 
-#: src/ui/pages/battery.rs:235 data/resources/ui/pages/gpu.ui:55
+#: src/ui/pages/battery.rs:250 data/resources/ui/pages/gpu.ui:55
 msgid "Power Usage"
 msgstr "Споживання електроенергії"
 
-#: src/ui/pages/battery.rs:293 src/ui/pages/drive.rs:349
-#: src/ui/pages/drive.rs:379 src/ui/pages/network.rs:333
-#: src/ui/pages/network.rs:367
+#: src/ui/pages/battery.rs:307 src/ui/pages/drive.rs:364
+#: src/ui/pages/drive.rs:394 src/ui/pages/network.rs:348
+#: src/ui/pages/network.rs:382
 msgid "Highest:"
 msgstr "Пікове навантаження:"
 
-#: src/ui/pages/cpu.rs:236 src/ui/pages/gpu.rs:222
+#: src/ui/pages/cpu.rs:250 src/ui/pages/gpu.rs:240
 msgid "Total Usage"
 msgstr "Загальне використання"
 
-#: src/ui/pages/cpu.rs:251 src/ui/pages/cpu.rs:368 src/ui/pages/cpu.rs:372
-msgid "CPU {}"
-msgstr "Процесор {}"
-
-#: src/ui/pages/drive.rs:251
+#: src/ui/pages/drive.rs:266
 msgid "Drive Activity"
 msgstr "Активність диску"
 
-#: src/ui/pages/drive.rs:258
+#: src/ui/pages/drive.rs:273
 msgid "Read Speed"
 msgstr "Швидкість читання"
 
-#: src/ui/pages/drive.rs:262
+#: src/ui/pages/drive.rs:277
 msgid "Write Speed"
 msgstr "Швидкість запису"
 
-#: src/ui/pages/drive.rs:416 src/ui/pages/drive.rs:426
+#: src/ui/pages/drive.rs:431 src/ui/pages/drive.rs:441
 msgid "Yes"
 msgstr "Так"
 
 #. Translators: This is an abbreviation for "Read" and "Write". This is displayed in the sidebar so your
 #. translation should preferably be quite short or an abbreviation
-#: src/ui/pages/drive.rs:438
+#: src/ui/pages/drive.rs:453
 msgid "R: {} · W: {}"
 msgstr "Чит.: {} · Зап.: {}"
 
-#: src/ui/pages/gpu.rs:230
+#: src/ui/pages/gpu.rs:248
 msgid "Video Encoder/Decoder Usage"
 msgstr "Використання відео кодувальника/декодувальника"
 
-#: src/ui/pages/gpu.rs:236
+#: src/ui/pages/gpu.rs:254
 msgid "Video Encoder Usage"
 msgstr "Використання кодувальника"
 
-#: src/ui/pages/gpu.rs:241
+#: src/ui/pages/gpu.rs:259
 msgid "Video Decoder Usage"
 msgstr "Використання декодувальника"
 
-#: src/ui/pages/gpu.rs:246
+#: src/ui/pages/gpu.rs:264
 msgid "Video Memory Usage"
 msgstr "Використання відеопам'яті"
 
-#: src/ui/pages/gpu.rs:409
+#: src/ui/pages/gpu.rs:427
 msgid "VRAM: {}"
 msgstr "Відеопам'ять: {}"
 
-#: src/ui/pages/memory.rs:211
+#: src/ui/pages/memory.rs:225
 msgid "Swap"
 msgstr "Swap"
 
-#: src/ui/pages/memory.rs:275
+#: src/ui/pages/memory.rs:289
 msgid "{} of {}"
 msgstr "{} із {}"
 
-#: src/ui/pages/memory.rs:278
+#: src/ui/pages/memory.rs:292
 msgid "{} MT/s"
 msgstr "{} МТ/с"
 
 #. Translators: This will be displayed in the sidebar, so your translation for "Swap" should
 #. preferably be quite short or an abbreviation
-#: src/ui/pages/memory.rs:352
+#: src/ui/pages/memory.rs:369
 msgid "{} / {} · Swap: {} %"
 msgstr "{} / {} · Swap: {} %"
 
-#: src/ui/pages/network.rs:149 src/utils/network.rs:128
+#: src/ui/pages/network.rs:155 src/utils/network.rs:128
 msgid "Network Interface"
 msgstr "Мережевий інтерфейс"
 
-#: src/ui/pages/network.rs:245
+#: src/ui/pages/network.rs:260
 msgid "Receiving"
 msgstr "Отримується"
 
-#: src/ui/pages/network.rs:249
+#: src/ui/pages/network.rs:264
 msgid "Sending"
 msgstr "Відправляється"
 
 #. Translators: This is an abbreviation for "Receive" and "Send". This is displayed in the sidebar so
 #. your translation should preferably be quite short or an abbreviation
-#: src/ui/pages/network.rs:390
+#: src/ui/pages/network.rs:405
 msgid "R: {} · S: {}"
 msgstr "Отрим.: {} · Надсил.: {}"
 
-#: src/ui/pages/processes/mod.rs:157 data/resources/ui/window.ui:96
+#: src/ui/pages/processes/mod.rs:171 data/resources/ui/window.ui:96
 #: data/resources/ui/window.ui:103
 #: data/resources/ui/dialogs/settings_dialog.ui:188
 msgid "Processes"
 msgstr "Процеси"
 
-#: src/ui/pages/processes/mod.rs:546
+#: src/ui/pages/processes/mod.rs:708
 msgid "Running Processes: {}"
 msgstr "Запущених процесів: {}"
 
-#: src/ui/pages/processes/mod.rs:599
+#: src/ui/pages/processes/mod.rs:796
 msgid "Process"
 msgstr "Назва процесу"
 
-#: src/ui/pages/processes/mod.rs:645
-#: data/resources/ui/dialogs/process_dialog.ui:181
-#: data/resources/ui/dialogs/settings_dialog.ui:194
+#: src/ui/pages/processes/mod.rs:857
+#: data/resources/ui/dialogs/process_dialog.ui:177
+#: data/resources/ui/dialogs/settings_dialog.ui:205
 msgid "Process ID"
 msgstr "Ідентифікатор процесу"
 
-#: src/ui/pages/processes/mod.rs:685
-#: data/resources/ui/dialogs/process_dialog.ui:208
-#: data/resources/ui/dialogs/settings_dialog.ui:199
+#: src/ui/pages/processes/mod.rs:910
+#: data/resources/ui/dialogs/process_dialog.ui:204
+#: data/resources/ui/dialogs/settings_dialog.ui:210
 msgid "User"
 msgstr "Користувач"
 
-#: src/ui/pages/processes/mod.rs:1217
-#: data/resources/ui/dialogs/process_dialog.ui:149
-#: data/resources/ui/dialogs/settings_dialog.ui:254
+#: src/ui/pages/processes/mod.rs:1585
+#: data/resources/ui/dialogs/process_dialog.ui:145
+#: data/resources/ui/dialogs/settings_dialog.ui:265
 msgid "Total CPU Time"
 msgstr "Загальне використання процесору"
 
-#: src/ui/pages/processes/mod.rs:1263
-#: data/resources/ui/dialogs/process_dialog.ui:158
-#: data/resources/ui/dialogs/settings_dialog.ui:259
+#: src/ui/pages/processes/mod.rs:1644
+#: data/resources/ui/dialogs/process_dialog.ui:154
+#: data/resources/ui/dialogs/settings_dialog.ui:270
 msgid "User CPU Time"
 msgstr "Використання процесору користувачем"
 
-#: src/ui/pages/processes/mod.rs:1309
-#: data/resources/ui/dialogs/process_dialog.ui:167
-#: data/resources/ui/dialogs/settings_dialog.ui:264
+#: src/ui/pages/processes/mod.rs:1703
+#: data/resources/ui/dialogs/process_dialog.ui:163
+#: data/resources/ui/dialogs/settings_dialog.ui:275
 msgid "System CPU Time"
 msgstr "Системне використання процессору"
 
-#: src/ui/pages/processes/mod.rs:1364
+#: src/ui/pages/processes/mod.rs:1762
+#: data/resources/ui/dialogs/process_options_dialog.ui:87
+#: data/resources/ui/dialogs/settings_dialog.ui:280
+msgid "Priority"
+msgstr "Пріорітет"
+
+#: src/ui/pages/processes/mod.rs:1838
 msgid ""
 "Halting a process can come with serious risks such as losing data and "
 "security implications. Use with caution."
@@ -448,7 +463,7 @@ msgstr ""
 "Зупинка процесу може призвести до серйозних ризиків, такі як: втрата даних і "
 "проблеми з безпекою. Продовжуйте на свій власний ризик."
 
-#: src/ui/pages/processes/mod.rs:1365
+#: src/ui/pages/processes/mod.rs:1839
 msgid ""
 "Killing a process can come with serious risks such as losing data and "
 "security implications. Use with caution."
@@ -456,43 +471,81 @@ msgstr ""
 "Знищення процесу може призвести до серйозних ризиків, такі як: втрата даних "
 "і проблеми з безпекою. Продовжуйте на свій власний ризик."
 
-#: src/ui/pages/processes/mod.rs:1372 data/resources/ui/pages/processes.ui:97
+#: src/ui/pages/processes/mod.rs:1846 data/resources/ui/pages/processes.ui:22
+#: data/resources/ui/pages/processes.ui:146
 msgid "End Process"
 msgstr "Завершити процес"
 
-#: src/ui/pages/processes/mod.rs:1373 data/resources/ui/pages/processes.ui:10
+#: src/ui/pages/processes/mod.rs:1847 data/resources/ui/pages/processes.ui:10
+#: data/resources/ui/pages/processes.ui:30
 msgid "Halt Process"
 msgstr "Зупинити процес"
 
-#: src/ui/pages/processes/mod.rs:1374 data/resources/ui/pages/processes.ui:6
+#: src/ui/pages/processes/mod.rs:1848 data/resources/ui/pages/processes.ui:6
+#: data/resources/ui/pages/processes.ui:26
 msgid "Kill Process"
 msgstr "Знищити процес"
 
-#: src/ui/pages/processes/mod.rs:1375 data/resources/ui/pages/processes.ui:14
+#: src/ui/pages/processes/mod.rs:1849 data/resources/ui/pages/processes.ui:14
+#: data/resources/ui/pages/processes.ui:34
 msgid "Continue Process"
 msgstr "Продовжити процес"
 
-#: src/ui/window.rs:284
+#: src/ui/pages/mod.rs:29
+#: data/resources/ui/dialogs/process_options_dialog.ui:91
+msgid "Very High"
+msgstr "Дуже високий"
+
+#: src/ui/pages/mod.rs:33
+#: data/resources/ui/dialogs/process_options_dialog.ui:92
+msgid "High"
+msgstr "Високий"
+
+#: src/ui/pages/mod.rs:37
+#: data/resources/ui/dialogs/process_options_dialog.ui:93
+#: data/resources/ui/dialogs/settings_dialog.ui:57
+msgid "Normal"
+msgstr "Нормальний"
+
+#: src/ui/pages/mod.rs:41
+#: data/resources/ui/dialogs/process_options_dialog.ui:94
+msgid "Low"
+msgstr "Низький"
+
+#: src/ui/pages/mod.rs:45
+#: data/resources/ui/dialogs/process_options_dialog.ui:95
+msgid "Very Low"
+msgstr "Дуже низький"
+
+#: src/ui/window.rs:300
 msgid "GPU {}"
 msgstr "Відеокарта {}"
 
-#: src/ui/window.rs:884
+#: src/ui/window.rs:868
+msgid "Successfully adjusted {}"
+msgstr "Успішно відкориговано {}"
+
+#: src/ui/window.rs:869
+msgid "There was a problem adjusting {}"
+msgstr "Виникли проблема при коригуванні {}"
+
+#: src/ui/window.rs:949
 msgid "Successfully ended {}"
 msgstr "Успішно завершено {}"
 
-#: src/ui/window.rs:885
+#: src/ui/window.rs:950
 msgid "Successfully halted {}"
 msgstr "Успішно зупинено {}"
 
-#: src/ui/window.rs:886
+#: src/ui/window.rs:951
 msgid "Successfully killed {}"
 msgstr "Успішно знищено {}"
 
-#: src/ui/window.rs:887
+#: src/ui/window.rs:952
 msgid "Successfully continued {}"
 msgstr "Успішно продовжено {}"
 
-#: src/ui/window.rs:894
+#: src/ui/window.rs:959
 msgid "There was a problem ending a process"
 msgid_plural "There were problems ending {} processes"
 msgstr[0] ""
@@ -501,44 +554,44 @@ msgstr[0] ""
 msgstr[1] "Виникли проблеми при завершені {} процесів"
 msgstr[2] "Виникли проблеми при завершені {} процесів"
 
-#: src/ui/window.rs:900
+#: src/ui/window.rs:965
 msgid "There was a problem halting a process"
 msgid_plural "There were problems halting {} processes"
 msgstr[0] "Виникли проблеми при зупинці {} процесу"
 msgstr[1] "Виникли проблеми при зупинці {} процесів"
 msgstr[2] "Виникли проблеми при зупинці {} процесів"
 
-#: src/ui/window.rs:906
+#: src/ui/window.rs:971
 msgid "There was a problem killing a process"
 msgid_plural "There were problems killing {} processes"
 msgstr[0] "Виникли проблеми при знищенні {} процесу"
 msgstr[1] "Виникли проблеми при знищенні {} процесів"
 msgstr[2] "Виникли проблеми при знищенні {} процесів"
 
-#: src/ui/window.rs:912
+#: src/ui/window.rs:977
 msgid "There was a problem continuing a process"
 msgid_plural "There were problems continuing {} processes"
 msgstr[0] "Виникли проблеми при продовженні {} процесу"
 msgstr[1] "Виникли проблеми при продовженні {} процесів"
 msgstr[2] "Виникли проблеми при продовженні {} процесів"
 
-#: src/ui/window.rs:922
+#: src/ui/window.rs:987
 msgid "There was a problem ending {}"
 msgstr "Виникли проблема при продовженні {}"
 
-#: src/ui/window.rs:923
+#: src/ui/window.rs:988
 msgid "There was a problem halting {}"
 msgstr "Виникли проблема при зупинці {}"
 
-#: src/ui/window.rs:924
+#: src/ui/window.rs:989
 msgid "There was a problem killing {}"
 msgstr "Сталася проблема при знищенні {}"
 
-#: src/ui/window.rs:925
+#: src/ui/window.rs:990
 msgid "There was a problem continuing {}"
 msgstr "Сталася проблема при продовженні {}"
 
-#: src/utils/app.rs:771
+#: src/utils/app.rs:220
 msgid "System Processes"
 msgstr "Системні процеси"
 
@@ -562,43 +615,43 @@ msgstr "Повна"
 msgid "Unknown"
 msgstr "Невідомо"
 
-#: src/utils/battery.rs:135
+#: src/utils/battery.rs:130
 msgid "Nickel-Metal Hydride"
 msgstr "Нікель-металевий гідрид"
 
-#: src/utils/battery.rs:136
+#: src/utils/battery.rs:131
 msgid "Nickel-Cadmium"
 msgstr "Нікель-кадмій"
 
-#: src/utils/battery.rs:137
+#: src/utils/battery.rs:132
 msgid "Nickel-Zinc"
 msgstr "Нікель-цинк"
 
-#: src/utils/battery.rs:138
+#: src/utils/battery.rs:133
 msgid "Lead-Acid"
 msgstr "Свинець"
 
-#: src/utils/battery.rs:139
+#: src/utils/battery.rs:134
 msgid "Lithium-Ion"
 msgstr "Літій-іон"
 
-#: src/utils/battery.rs:140
+#: src/utils/battery.rs:135
 msgid "Lithium Iron Phosphate"
 msgstr "Літієвий залізний фосфат"
 
-#: src/utils/battery.rs:141
+#: src/utils/battery.rs:136
 msgid "Lithium Polymer"
 msgstr "Літій полімер"
 
-#: src/utils/battery.rs:143
+#: src/utils/battery.rs:138
 msgid "Rechargeable Alkaline Managanese"
 msgstr "Акумуляторний лужний марганець"
 
-#: src/utils/battery.rs:239
+#: src/utils/battery.rs:232
 msgid "{} Battery"
 msgstr "{} батарея"
 
-#: src/utils/battery.rs:241
+#: src/utils/battery.rs:234
 msgid "Battery"
 msgstr "Батарея"
 
@@ -1177,6 +1230,11 @@ msgctxt "shortcut window"
 msgid "Show Information for App/Process"
 msgstr "Показати інформацію про додаток/процес"
 
+#: data/resources/ui/shortcuts.ui:68
+msgctxt "shortcut window"
+msgid "Show Process Options"
+msgstr "Показати налаштування процесу"
+
 #: data/resources/ui/window.ui:6
 msgid "Preferences"
 msgstr "Налаштування"
@@ -1193,8 +1251,8 @@ msgstr "Про Ресурси"
 msgid "App Information"
 msgstr "Інформація про додаток"
 
-#: data/resources/ui/dialogs/app_dialog.ui:74
-#: data/resources/ui/dialogs/process_dialog.ui:52
+#: data/resources/ui/dialogs/app_dialog.ui:70
+#: data/resources/ui/dialogs/process_dialog.ui:48
 #: data/resources/ui/pages/battery.ui:22 data/resources/ui/pages/cpu.ui:37
 #: data/resources/ui/pages/cpu.ui:50 data/resources/ui/pages/drive.ui:22
 #: data/resources/ui/pages/gpu.ui:22 data/resources/ui/pages/memory.ui:31
@@ -1202,29 +1260,29 @@ msgstr "Інформація про додаток"
 msgid "Usage"
 msgstr "Використання"
 
-#: data/resources/ui/dialogs/app_dialog.ui:169
-#: data/resources/ui/dialogs/process_dialog.ui:174
+#: data/resources/ui/dialogs/app_dialog.ui:165
+#: data/resources/ui/dialogs/process_dialog.ui:170
 #: data/resources/ui/pages/battery.ui:33 data/resources/ui/pages/cpu.ui:89
 #: data/resources/ui/pages/drive.ui:54 data/resources/ui/pages/gpu.ui:80
 #: data/resources/ui/pages/memory.ui:42 data/resources/ui/pages/network.ui:51
 msgid "Properties"
 msgstr "Властивості"
 
-#: data/resources/ui/dialogs/app_dialog.ui:175
+#: data/resources/ui/dialogs/app_dialog.ui:171
 msgid "ID"
 msgstr "Ідентифікатор"
 
-#: data/resources/ui/dialogs/app_dialog.ui:185
-#: data/resources/ui/dialogs/process_dialog.ui:190
+#: data/resources/ui/dialogs/app_dialog.ui:181
+#: data/resources/ui/dialogs/process_dialog.ui:186
 msgid "Running Since"
 msgstr "Запущено з"
 
-#: data/resources/ui/dialogs/app_dialog.ui:193
+#: data/resources/ui/dialogs/app_dialog.ui:189
 msgid "Running Processes"
 msgstr "Запущених процесів"
 
-#: data/resources/ui/dialogs/app_dialog.ui:202
-#: data/resources/ui/dialogs/process_dialog.ui:226
+#: data/resources/ui/dialogs/app_dialog.ui:198
+#: data/resources/ui/dialogs/process_dialog.ui:222
 msgid "Containerized"
 msgstr "Контейнірізовано"
 
@@ -1232,13 +1290,43 @@ msgstr "Контейнірізовано"
 msgid "Process Information"
 msgstr "Інформація про процес"
 
-#: data/resources/ui/dialogs/process_dialog.ui:199
+#: data/resources/ui/dialogs/process_dialog.ui:195
 msgid "Commandline"
 msgstr "Аргументи командного рядку"
 
-#: data/resources/ui/dialogs/process_dialog.ui:217
+#: data/resources/ui/dialogs/process_dialog.ui:213
 msgid "Control Group"
 msgstr "Група контролю"
+
+#: data/resources/ui/dialogs/process_options_dialog.ui:7
+#: data/resources/ui/dialogs/process_options_dialog.ui:69
+msgid "Process Options"
+msgstr "Налаштування процесу"
+
+#: data/resources/ui/dialogs/process_options_dialog.ui:72
+msgid "Niceness"
+msgstr "Пріоритет (niceness)"
+
+#: data/resources/ui/dialogs/process_options_dialog.ui:73
+msgid ""
+"The priority of a process is given by its niceness. A lower niceness value "
+"correspond to a higher priority."
+msgstr ""
+"Пріоритет процесору у niceness значенні. Чим нижче значення - тим більший "
+"пріоритет."
+
+# Я так розумію, що мова йде про ось це: https://uk.wikipedia.org/wiki/%D0%A1%D0%BF%D0%BE%D1%80%D1%96%D0%B4%D0%BD%D0%B5%D0%BD%D1%96%D1%81%D1%82%D1%8C_%D0%BF%D1%80%D0%BE%D1%86%D0%B5%D1%81%D0%BE%D1%80%D0%B0 але я ні на що не претендую.
+#: data/resources/ui/dialogs/process_options_dialog.ui:103
+msgid "Processor Affinity"
+msgstr "Спорідненість процесора"
+
+#: data/resources/ui/dialogs/process_options_dialog.ui:108
+msgid "Toggle All"
+msgstr "Перемикнути всі"
+
+#: data/resources/ui/dialogs/process_options_dialog.ui:111
+msgid "Select which processor cores the process is allowed to run on"
+msgstr "Оберіть на яких ядрах процесору дозволено працювати процесу"
 
 #: data/resources/ui/dialogs/settings_dialog.ui:7
 msgid "General"
@@ -1301,10 +1389,6 @@ msgstr "Дуже повільно"
 #: data/resources/ui/dialogs/settings_dialog.ui:56
 msgid "Slow"
 msgstr "Повільно"
-
-#: data/resources/ui/dialogs/settings_dialog.ui:57
-msgid "Normal"
-msgstr "Нормально"
 
 #: data/resources/ui/dialogs/settings_dialog.ui:58
 msgid "Fast"
@@ -1372,52 +1456,69 @@ msgstr ""
 "ядер"
 
 #: data/resources/ui/dialogs/settings_dialog.ui:130
-#: data/resources/ui/dialogs/settings_dialog.ui:191
+#: data/resources/ui/dialogs/settings_dialog.ui:202
 msgid "Information Columns"
 msgstr "Колонки з інформацією"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:274
+#: data/resources/ui/dialogs/settings_dialog.ui:191
+#: data/resources/ui/pages/cpu.ui:22 data/resources/ui/pages/processes.ui:40
+msgid "Options"
+msgstr "Налаштування"
+
+#: data/resources/ui/dialogs/settings_dialog.ui:194
+msgid "Show Niceness Values"
+msgstr "Показати значення пріоритету (niceness)"
+
+#: data/resources/ui/dialogs/settings_dialog.ui:195
+msgid ""
+"Display priorities as niceness to allow for more fine-grained adjustments"
+msgstr ""
+"Показувати пріоритети у вигляді значення niceness для більш тонкого "
+"корегування"
+
+#: data/resources/ui/dialogs/settings_dialog.ui:290
 msgid "Devices"
 msgstr "Пристрої"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:277
+#: data/resources/ui/dialogs/settings_dialog.ui:293
 msgid "Drives"
 msgstr "Накопичувачі"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:280
+#: data/resources/ui/dialogs/settings_dialog.ui:296
 msgid "Show Virtual Drives"
 msgstr "Показати віртуальні диски"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:281
+#: data/resources/ui/dialogs/settings_dialog.ui:297
 msgid "Virtual drives are for example ZFS volumes or mapped devices"
 msgstr "Віртуальні диски, наприклад, ZFS розділ"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:291
+#: data/resources/ui/dialogs/settings_dialog.ui:307
 msgid "Show Virtual Network Interfaces"
 msgstr "Показати віртуальні мережеві інтерфейси"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:292
+#: data/resources/ui/dialogs/settings_dialog.ui:308
 msgid "Virtual network interfaces are for example bridges or VPN tunnels"
 msgstr "Віртуальні мережеві інтерфейси, накшталт мостів або VPN тунелів"
 
-#: data/resources/ui/pages/applications.ui:50
+#: data/resources/ui/pages/applications.ui:40
+#: data/resources/ui/pages/applications.ui:116
+#: data/resources/ui/pages/applications.ui:118
+msgid "Show App Information"
+msgstr "Показати інформацію про додаток"
+
+#: data/resources/ui/pages/applications.ui:80
 msgid "Search applications"
 msgstr "Шукати додатки"
 
-#: data/resources/ui/pages/applications.ui:68
-#: data/resources/ui/pages/processes.ui:68
+#: data/resources/ui/pages/applications.ui:98
+#: data/resources/ui/pages/processes.ui:104
 msgid "Search"
 msgstr "Шукати"
 
-#: data/resources/ui/pages/applications.ui:70
-#: data/resources/ui/pages/processes.ui:70
+#: data/resources/ui/pages/applications.ui:100
+#: data/resources/ui/pages/processes.ui:106
 msgid "Toggle search field"
 msgstr "Перемкнути поле пошуку"
-
-#: data/resources/ui/pages/applications.ui:86
-#: data/resources/ui/pages/applications.ui:88
-msgid "Show App Information"
-msgstr "Показати інформацію про додаток"
 
 #: data/resources/ui/pages/battery.ui:36
 msgid "Battery Health"
@@ -1447,10 +1548,6 @@ msgstr "Назва моделі"
 #: data/resources/ui/pages/battery.ui:90 data/resources/ui/pages/drive.ui:66
 msgid "Device"
 msgstr "Пристрій"
-
-#: data/resources/ui/pages/cpu.ui:22
-msgid "Options"
-msgstr "Налаштування"
 
 #: data/resources/ui/pages/cpu.ui:26
 msgid "Show Usages of Logical CPUs"
@@ -1572,14 +1669,20 @@ msgstr "Інтерфейс"
 msgid "Hardware Address"
 msgstr "Апаратна адреса"
 
-#: data/resources/ui/pages/processes.ui:50
+#: data/resources/ui/pages/processes.ui:46
+#: data/resources/ui/pages/processes.ui:135
+#: data/resources/ui/pages/processes.ui:137
+msgid "Show Process Information"
+msgstr "Показати інформацію про процес"
+
+#: data/resources/ui/pages/processes.ui:86
 msgid "Search processes"
 msgstr "Шукати процеси"
 
-#: data/resources/ui/pages/processes.ui:86
-#: data/resources/ui/pages/processes.ui:88
-msgid "Show Process Information"
-msgstr "Показати інформацію про процес"
+#: data/resources/ui/pages/processes.ui:122
+#: data/resources/ui/pages/processes.ui:124
+msgid "Show Process Options"
+msgstr "Показати налаштування процесу"
 
 #~ msgid "Window width"
 #~ msgstr "Ширина вікна"

--- a/po/uk.po
+++ b/po/uk.po
@@ -5,8 +5,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: resources\n"
 "Report-Msgid-Bugs-To: https://github.com/nokyan/resources/issues\n"
-"POT-Creation-Date: 2024-08-09 19:44+0200\n"
-"PO-Revision-Date: 2024-08-09 23:54+0300\n"
+"POT-Creation-Date: 2024-08-09 23:34+0200\n"
+"PO-Revision-Date: 2024-08-10 00:45+0300\n"
 "Last-Translator: volkov <volkovissocool@gmail.com>\n"
 "Language-Team: volkov <volkovissocool@gmail.com>\n"
 "Language: uk\n"
@@ -492,28 +492,22 @@ msgid "Continue Process"
 msgstr "Продовжити процес"
 
 #: src/ui/pages/mod.rs:29
-#: data/resources/ui/dialogs/process_options_dialog.ui:91
 msgid "Very High"
 msgstr "Дуже високий"
 
 #: src/ui/pages/mod.rs:33
-#: data/resources/ui/dialogs/process_options_dialog.ui:92
 msgid "High"
 msgstr "Високий"
 
 #: src/ui/pages/mod.rs:37
-#: data/resources/ui/dialogs/process_options_dialog.ui:93
-#: data/resources/ui/dialogs/settings_dialog.ui:57
 msgid "Normal"
 msgstr "Нормальний"
 
 #: src/ui/pages/mod.rs:41
-#: data/resources/ui/dialogs/process_options_dialog.ui:94
 msgid "Low"
 msgstr "Низький"
 
 #: src/ui/pages/mod.rs:45
-#: data/resources/ui/dialogs/process_options_dialog.ui:95
 msgid "Very Low"
 msgstr "Дуже низький"
 
@@ -1315,6 +1309,31 @@ msgstr ""
 "Пріоритет процесору у niceness значенні. Чим нижче значення - тим більший "
 "пріоритет."
 
+#: data/resources/ui/dialogs/process_options_dialog.ui:91
+msgctxt "process priority"
+msgid "Very High"
+msgstr "Дуже високий"
+
+#: data/resources/ui/dialogs/process_options_dialog.ui:92
+msgctxt "process priority"
+msgid "High"
+msgstr "Високий"
+
+#: data/resources/ui/dialogs/process_options_dialog.ui:93
+msgctxt "process priority"
+msgid "Normal"
+msgstr "Нормальний"
+
+#: data/resources/ui/dialogs/process_options_dialog.ui:94
+msgctxt "process priority"
+msgid "Low"
+msgstr "Низький"
+
+#: data/resources/ui/dialogs/process_options_dialog.ui:95
+msgctxt "process priority"
+msgid "Very Low"
+msgstr "Дуже низький"
+
 # Я так розумію, що мова йде про ось це: https://uk.wikipedia.org/wiki/%D0%A1%D0%BF%D0%BE%D1%80%D1%96%D0%B4%D0%BD%D0%B5%D0%BD%D1%96%D1%81%D1%82%D1%8C_%D0%BF%D1%80%D0%BE%D1%86%D0%B5%D1%81%D0%BE%D1%80%D0%B0 але я ні на що не претендую.
 #: data/resources/ui/dialogs/process_options_dialog.ui:103
 msgid "Processor Affinity"
@@ -1383,20 +1402,29 @@ msgstr ""
 "процессору"
 
 #: data/resources/ui/dialogs/settings_dialog.ui:55
+msgctxt "UI refresh speed"
 msgid "Very Slow"
-msgstr "Дуже повільно"
+msgstr "Дуже повільна"
 
 #: data/resources/ui/dialogs/settings_dialog.ui:56
+msgctxt "UI refresh speed"
 msgid "Slow"
-msgstr "Повільно"
+msgstr "Повільна"
+
+#: data/resources/ui/dialogs/settings_dialog.ui:57
+msgctxt "UI refresh speed"
+msgid "Normal"
+msgstr "Нормальна"
 
 #: data/resources/ui/dialogs/settings_dialog.ui:58
+msgctxt "UI refresh speed"
 msgid "Fast"
-msgstr "Швидко"
+msgstr "Швидка"
 
 #: data/resources/ui/dialogs/settings_dialog.ui:59
+msgctxt "UI refresh speed"
 msgid "Very Fast"
-msgstr "Дуже швидко"
+msgstr "Дуже швидка"
 
 #: data/resources/ui/dialogs/settings_dialog.ui:67
 msgid "Show Graph Grids"


### PR DESCRIPTION
Added new strings..

Also, could you please provide 2 different contexts for process priority and for updating speed in list of processes/apps?
I don't know about other non-slavic languages, but in Ukrainian (and some other Slavic languages) - "Priority - Very High" become "Пріорітет - Дуже висок`ий`", but "Refresh Speed - Very High" become "Швидкість оновлення - Дуже висок`а`", same for others: "High", "Normal", "Low", "Very Low". In this case, words will change depending on gender that used for this words. This is not the biggest deal, but it looks slightly wrong.