### PR TITLE
Fix missing trailing slash in GNOME circle link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <a href='https://flathub.org/apps/net.nokyan.Resources'><img width='240' alt='Download on Flathub' src='https://dl.flathub.org/assets/badges/flathub-badge-en.png'/></a>
 
 [![GNOME Circle](https://circle.gnome.org/assets/button/badge.svg
-)](https://apps.gnome.org/app/net.nokyan.Resources) [![Please do not theme this app](https://stopthemingmy.app/badge.svg)](https://stopthemingmy.app)  
+)](https://apps.gnome.org/app/net.nokyan.Resources/) [![Please do not theme this app](https://stopthemingmy.app/badge.svg)](https://stopthemingmy.app)  
 
 Resources is a simple yet powerful monitor for your system resources and processes, written in Rust and using GTK 4 and libadwaita for its GUI. It’s capable of displaying usage and details of your CPU, memory, GPUs, network interfaces and block devices. It’s also capable of listing and terminating running graphical applications as well as processes.
 

--- a/data/net.nokyan.Resources.metainfo.xml.in.in
+++ b/data/net.nokyan.Resources.metainfo.xml.in.in
@@ -29,7 +29,7 @@
       <li>Batteries</li>
     </ul>
   </description>
-  <url type="homepage">https://apps.gnome.org/app/net.nokyan.Resources</url>
+  <url type="homepage">https://apps.gnome.org/app/net.nokyan.Resources/</url>
   <url type="contribute">https://welcome.gnome.org/app/Resources/</url>
   <url type="bugtracker">https://github.com/nokyan/resources/issues</url>
   <url type="vcs-browser">https://github.com/nokyan/resources</url>

--- a/resources.doap
+++ b/resources.doap
@@ -7,7 +7,7 @@
 
   <name xml:lang="en">Resources</name>
   <shortdesc xml:lang="en">Keep an eye on system resources</shortdesc>
-  <homepage rdf:resource="https://apps.gnome.org/app/net.nokyan.Resources"/>
+  <homepage rdf:resource="https://apps.gnome.org/app/net.nokyan.Resources/"/>
   <bug-database rdf:resource="https://github.com/nokyan/resources/issues/"/>
 
   <programming-language>Rust</programming-language>

--- a/src/application.rs
+++ b/src/application.rs
@@ -265,7 +265,7 @@ impl Application {
             .developers(vec!["nokyan <nokyan@tuta.io>".to_string()])
             .license_type(gtk::License::Gpl30)
             .version(config::VERSION)
-            .website("https://apps.gnome.org/app/net.nokyan.Resources")
+            .website("https://apps.gnome.org/app/net.nokyan.Resources/")
             .build();
 
         about.add_link(


### PR DESCRIPTION
The previous link resulted in a redirect