### PR TITLE
Use appstreamcli to validate appdata

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -43,11 +43,11 @@ appdata_file = i18n.merge_file(
   install_dir: datadir / 'metainfo'
 )
 # Validate Appdata
-if appstream_util.found()
+if appstreamcli.found()
   test(
-    'validate-appdata', appstream_util,
+    'validate-appdata', appstreamcli,
     args: [
-      'validate', '--nonet', appdata_file.full_path()
+      'validate', '--no-net', '--explain', appdata_file.full_path()
     ],
     depends: appdata_file,
   )

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@ dependency('libadwaita-1', version: '>= 1.5.0')
 glib_compile_resources = find_program('glib-compile-resources', required: true)
 glib_compile_schemas = find_program('glib-compile-schemas', required: true)
 desktop_file_validate = find_program('desktop-file-validate', required: false)
-appstream_util = find_program('appstream-util', required: false)
+appstreamcli = find_program('appstreamcli', required: false)
 cargo = find_program('cargo', required: true)
 
 version = meson.project_version()


### PR DESCRIPTION
appstream-glib is under heavy maintenance mode and recommends using appstream instead.