### PR TITLE
Added back original app name to app tags

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -35,7 +35,7 @@ msgstr "Monitore os recursos do sistema"
 msgid ""
 "System;Resources;Monitor;Processes;Usage;Task;Manager;CPU;RAM;Memory;GPU;"
 msgstr ""
-"Sistema;Recursos;Monitor;Processos;Uso;Tarefas;Gerenciador;CPU;RAM;Memória;"
+"Sistema;Resources;Recursos;Monitor;Processos;Uso;Tarefas;Gerenciador;CPU;RAM;Memória;"
 "GPU;"
 
 #: data/net.nokyan.Resources.metainfo.xml.in.in:17


### PR DESCRIPTION
Added back the original app name to the app tags, to make it easier for users to find it in GNOME Shell search.