### PR TITLE
Use 'content_height' instead of 'height_request' to stop dialogs from cutting off at very small heights

### DIFF
--- a/data/resources/ui/dialogs/app_dialog.ui
+++ b/data/resources/ui/dialogs/app_dialog.ui
@@ -2,8 +2,8 @@
 <interface>
   <template class="ResAppDialog" parent="AdwDialog">
     <property name="width_request">360</property>
-    <property name="height_request">600</property>
     <property name="content_width">480</property>
+    <property name="content_height">600</property>
     <property name="title" translatable="yes">App Information</property>
     <child>
       <object class="AdwToolbarView">

--- a/data/resources/ui/dialogs/process_dialog.ui
+++ b/data/resources/ui/dialogs/process_dialog.ui
@@ -2,8 +2,8 @@
 <interface>
   <template class="ResProcessDialog" parent="AdwDialog">
     <property name="width_request">360</property>
-    <property name="height_request">600</property>
     <property name="content_width">480</property>
+    <property name="content_height">600</property>
     <property name="title" translatable="yes">Process Information</property>
     <child>
       <object class="AdwToolbarView">

--- a/data/resources/ui/dialogs/process_options_dialog.ui
+++ b/data/resources/ui/dialogs/process_options_dialog.ui
@@ -2,8 +2,8 @@
 <interface>
   <template class="ResProcessOptionsDialog" parent="AdwDialog">
     <property name="width_request">360</property>
-    <property name="height_request">720</property>
     <property name="content_width">480</property>
+    <property name="content_height">600</property>
     <property name="title" translatable="yes">Process Options</property>
     <child>
       <object class="AdwToolbarView">


### PR DESCRIPTION
Resolves #333 