### PR TITLE
Consider sysfs usage for AMD and Intel again

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ If you’re packaging Resources for another distribution, feel free to send a pu
 
 Unofficially packaged in the [extra](https://archlinux.org/packages/extra/x86_64/resources/) repository.
 
-You can install it using `pacman` with no further configuration required.
+You can install Resources using `pacman` with no further configuration required.
 
 ```sh
 pacman -S resources

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -499,13 +499,22 @@ impl MainWindow {
                 // usage, which might not be what we want
 
                 let processes_gpu_fraction = apps_context.gpu_fraction(gpu_data.pci_slot);
-                gpu_data.usage_fraction = Some(processes_gpu_fraction.into());
+                gpu_data.usage_fraction = Some(f64::max(
+                    gpu_data.usage_fraction.unwrap_or(0.0),
+                    processes_gpu_fraction.into(),
+                ));
 
                 let processes_encode_fraction = apps_context.encoder_fraction(gpu_data.pci_slot);
-                gpu_data.encode_fraction = Some(processes_encode_fraction.into());
+                gpu_data.encode_fraction = Some(f64::max(
+                    gpu_data.encode_fraction.unwrap_or(0.0),
+                    processes_encode_fraction.into(),
+                ));
 
                 let processes_decode_fraction = apps_context.decoder_fraction(gpu_data.pci_slot);
-                gpu_data.decode_fraction = Some(processes_decode_fraction.into());
+                gpu_data.decode_fraction = Some(f64::max(
+                    gpu_data.decode_fraction.unwrap_or(0.0),
+                    processes_decode_fraction.into(),
+                ));
             }
 
             page.refresh_page(&gpu_data);

--- a/src/utils/gpu/mod.rs
+++ b/src/utils/gpu/mod.rs
@@ -54,11 +54,20 @@ impl GpuData {
     pub fn new(gpu: &Gpu) -> Self {
         let pci_slot = gpu.pci_slot();
 
-        let usage_fraction = gpu.usage().map(|usage| (usage as f64) / 100.0).ok();
+        let usage_fraction = gpu
+            .usage()
+            .map(|usage| ((usage as f64) / 100.0).clamp(0.0, 1.0))
+            .ok();
 
-        let encode_fraction = gpu.encode_usage().map(|usage| (usage as f64) / 100.0).ok();
+        let encode_fraction = gpu
+            .encode_usage()
+            .map(|usage| ((usage as f64) / 100.0).clamp(0.0, 1.0))
+            .ok();
 
-        let decode_fraction = gpu.decode_usage().map(|usage| (usage as f64) / 100.0).ok();
+        let decode_fraction = gpu
+            .decode_usage()
+            .map(|usage| ((usage as f64) / 100.0).clamp(0.0, 1.0))
+            .ok();
 
         let total_vram = gpu.total_vram().ok();
         let used_vram = gpu.used_vram().ok();


### PR DESCRIPTION
This fixes especially ROCm usage not being displayed in total GPU usage.
Resolves #220 