### PR TITLE
Fix usage statistics for NVIDIA being wrong

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -37,10 +37,11 @@ gettext_package = meson.project_name()
 if get_option('profile') == 'development'
   profile = 'Devel'
   vcs_tag = run_command('git', 'rev-parse', '--short', 'HEAD').stdout().strip()
-  if vcs_tag == ''
+  vcs_branch = run_command('git', 'rev-parse', '--abbrev-ref', 'HEAD').stdout().strip()
+  if vcs_tag == '' or vcs_branch == ''
     version_suffix = '-devel'
   else
-    version_suffix = '-@0@'.format(vcs_tag)
+    version_suffix = '-@0@/@1@'.format(vcs_branch, vcs_tag)
   endif
   application_id = '@0@.@1@'.format(base_id, profile)
 else

--- a/src/application.rs
+++ b/src/application.rs
@@ -283,7 +283,7 @@ impl Application {
 
     pub fn run(&self) {
         info!("Resources ({})", APP_ID);
-        info!("Version: {} ({})", VERSION, PROFILE);
+        info!("Version: {}", VERSION);
         info!("Datadir: {}", PKGDATADIR);
 
         if PROFILE == "Devel" {

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -44,6 +44,7 @@ mod imp {
     use std::{cell::RefCell, collections::HashMap};
 
     use crate::{
+        config::VERSION,
         ui::{
             pages::{
                 applications::ResApplications, cpu::ResCPU, memory::ResMemory,
@@ -158,6 +159,9 @@ mod imp {
             // Devel Profile
             if PROFILE == "Devel" {
                 obj.add_css_class("devel");
+                obj.set_title(Some(
+                    &format!("{} ({})", obj.title().unwrap_or_default(), VERSION).trim(),
+                ));
             }
 
             // Load latest window state

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -297,10 +297,8 @@ impl MainWindow {
         }
     }
 
-    fn init_gpu_pages(self: &MainWindow) -> Vec<Gpu> {
+    fn init_gpu_pages(self: &MainWindow, gpus: &[Gpu]) {
         let imp = self.imp();
-
-        let gpus = Gpu::get_gpus().unwrap_or_default();
 
         for (i, gpu) in gpus.iter().enumerate() {
             let page = ResGPU::new();
@@ -325,8 +323,6 @@ impl MainWindow {
                 .borrow_mut()
                 .insert(gpu.pci_slot(), (gpu.clone(), added_page));
         }
-
-        gpus
     }
 
     fn init_npu_pages(self: &MainWindow) -> Vec<Npu> {
@@ -365,6 +361,10 @@ impl MainWindow {
         let imp = self.imp();
 
         let gpus = Gpu::get_gpus().unwrap_or_default();
+
+        if !ARGS.disable_gpu_monitoring {
+            self.init_gpu_pages(&gpus);
+        }
 
         imp.resources_sidebar.set_stack(&imp.content_stack);
 
@@ -409,10 +409,6 @@ impl MainWindow {
             self.remove_page(imp.memory_page.child().downcast_ref().unwrap());
         } else {
             imp.memory.init();
-        }
-
-        if !ARGS.disable_gpu_monitoring {
-            self.init_gpu_pages();
         }
 
         if !ARGS.disable_npu_monitoring {

--- a/src/utils/gpu/mod.rs
+++ b/src/utils/gpu/mod.rs
@@ -56,20 +56,11 @@ impl GpuData {
     pub fn new(gpu: &Gpu) -> Self {
         let pci_slot = gpu.pci_slot();
 
-        let usage_fraction = gpu
-            .usage()
-            .map(|usage| (usage / 100.0).clamp(0.0, 1.0))
-            .ok();
+        let usage_fraction = gpu.usage().map(|usage| usage.clamp(0.0, 1.0)).ok();
 
-        let encode_fraction = gpu
-            .encode_usage()
-            .map(|usage| (usage / 100.0).clamp(0.0, 1.0))
-            .ok();
+        let encode_fraction = gpu.encode_usage().map(|usage| usage.clamp(0.0, 1.0)).ok();
 
-        let decode_fraction = gpu
-            .decode_usage()
-            .map(|usage| (usage / 100.0).clamp(0.0, 1.0))
-            .ok();
+        let decode_fraction = gpu.decode_usage().map(|usage| usage.clamp(0.0, 1.0)).ok();
 
         let total_vram = gpu.total_vram().ok();
         let used_vram = gpu.used_vram().ok();


### PR DESCRIPTION
Usage statistics for NVIDIA GPUs were divided by 100 once too often, leading to the displayed usage being mostly 0%.
This PR also includes appending the git branch name to the version string (which in Devel also contains the commit hash) and including the version string in the titlebar.

Resolves #198 
Resolves #412 