### PR TITLE
Raspberry Pi GPU support 

### DIFF
--- a/lib/process_data/src/lib.rs
+++ b/lib/process_data/src/lib.rs
@@ -11,6 +11,7 @@ use nvml_wrapper::{Device, Nvml};
 use pci_slot::PciSlot;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fmt::Display;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::os::linux::fs::MetadataExt;
@@ -46,6 +47,8 @@ static RE_IO_READ: Lazy<Regex> = lazy_regex!(r"read_bytes:\s*(\d+)");
 
 static RE_IO_WRITE: Lazy<Regex> = lazy_regex!(r"write_bytes:\s*(\d+)");
 
+static RE_DRM_DRIVER: Lazy<Regex> = lazy_regex!(r"drm-driver:\s*(.+)");
+
 static RE_DRM_PDEV: Lazy<Regex> =
     lazy_regex!(r"drm-pdev:\s*([0-9A-Fa-f]{4}:[0-9A-Fa-f]{2}:[0-9A-Fa-f]{2}\.[0-9A-Fa-f])");
 
@@ -67,11 +70,14 @@ static RE_DRM_MEMORY_VRAM: Lazy<Regex> = lazy_regex!(r"drm-memory-vram:\s*(\d+)\
 // AMD only
 static RE_DRM_MEMORY_GTT: Lazy<Regex> = lazy_regex!(r"drm-memory-gtt:\s*(\d+)\s*KiB");
 
-// Intel only
+// Intel and v3d only
 static RE_DRM_ENGINE_RENDER: Lazy<Regex> = lazy_regex!(r"drm-engine-render:\s*(\d+)\s*ns");
 
 // Intel only
 static RE_DRM_ENGINE_VIDEO: Lazy<Regex> = lazy_regex!(r"drm-engine-video:\s*(\d+)\s*ns");
+
+// v3d only
+static RE_DRM_TOTAL_MEMORY: Lazy<Regex> = lazy_regex!(r"drm-total-memory:\s*(\d+)\s*KiB");
 
 static NVML: Lazy<Result<Nvml, NvmlError>> = Lazy::new(Nvml::init);
 
@@ -115,6 +121,27 @@ pub enum Containerization {
     Snap,
 }
 
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize, Copy, PartialOrd, Ord)]
+pub enum GpuIdentifier {
+    PciSlot(PciSlot),
+    Enumerator(usize),
+}
+
+impl Default for GpuIdentifier {
+    fn default() -> Self {
+        GpuIdentifier::Enumerator(0)
+    }
+}
+
+impl Display for GpuIdentifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GpuIdentifier::PciSlot(pci_slot) => write!(f, "{}", pci_slot),
+            GpuIdentifier::Enumerator(e) => write!(f, "{}", e),
+        }
+    }
+}
+
 /// Represents GPU usage statistics per-process. Depending on the GPU manufacturer (which should be determined in
 /// Resources itself), these numbers need to interpreted differently
 ///
@@ -156,7 +183,7 @@ pub struct ProcessData {
     pub write_bytes: Option<u64>,
     pub timestamp: u64,
     /// Key: PCI Slot ID of the GPU
-    pub gpu_usage_stats: BTreeMap<PciSlot, GpuUsageStats>,
+    pub gpu_usage_stats: BTreeMap<GpuIdentifier, GpuUsageStats>,
 }
 
 impl ProcessData {
@@ -387,7 +414,7 @@ impl ProcessData {
         })
     }
 
-    fn gpu_usage_stats(proc_path: &Path, pid: i32) -> BTreeMap<PciSlot, GpuUsageStats> {
+    fn gpu_usage_stats(proc_path: &Path, pid: i32) -> BTreeMap<GpuIdentifier, GpuUsageStats> {
         let nvidia_stats = Self::nvidia_gpu_stats_all(pid);
         let mut other_stats = Self::other_gpu_usage_stats(proc_path, pid).unwrap_or_default();
         other_stats.extend(nvidia_stats);
@@ -397,7 +424,7 @@ impl ProcessData {
     fn other_gpu_usage_stats(
         proc_path: &Path,
         pid: i32,
-    ) -> Result<BTreeMap<PciSlot, GpuUsageStats>> {
+    ) -> Result<BTreeMap<GpuIdentifier, GpuUsageStats>> {
         let fdinfo_dir = proc_path.join("fdinfo");
 
         let mut seen_fds = HashSet::new();
@@ -484,28 +511,37 @@ impl ProcessData {
         Ok(return_map)
     }
 
-    fn read_fdinfo(fdinfo_file: &mut File, file_size: usize) -> Result<(PciSlot, GpuUsageStats)> {
+    fn read_fdinfo(
+        fdinfo_file: &mut File,
+        file_size: usize,
+    ) -> Result<(GpuIdentifier, GpuUsageStats)> {
         let mut content = String::with_capacity(file_size);
         fdinfo_file.read_to_string(&mut content)?;
         fdinfo_file.flush()?;
 
-        let pci_slot = RE_DRM_PDEV
+        let driver = RE_DRM_DRIVER
             .captures(&content)
             .and_then(|captures| captures.get(1))
-            .and_then(|capture| PciSlot::from_str(capture.as_str()).ok());
+            .map(|capture| capture.as_str());
 
-        if let Some(pci_slot) = pci_slot {
-            let gfx = RE_DRM_ENGINE_GFX // amd
+        if driver.is_some() {
+            let gpu_identifier = RE_DRM_PDEV
+                .captures(&content)
+                .and_then(|captures| captures.get(1))
+                .and_then(|capture| PciSlot::from_str(capture.as_str()).ok())
+                .map(|pci_slot| GpuIdentifier::PciSlot(pci_slot))
+                .unwrap_or_default();
+
+            let gfx = RE_DRM_ENGINE_GFX
                 .captures(&content)
                 .and_then(|captures| captures.get(1))
                 .and_then(|capture| capture.as_str().parse::<u64>().ok())
-                .or_else(|| {
-                    // intel
-                    RE_DRM_ENGINE_RENDER
-                        .captures(&content)
-                        .and_then(|captures| captures.get(1))
-                        .and_then(|capture| capture.as_str().parse::<u64>().ok())
-                })
+                .unwrap_or_default();
+
+            let render = RE_DRM_ENGINE_RENDER
+                .captures(&content)
+                .and_then(|captures| captures.get(1))
+                .and_then(|capture| capture.as_str().parse::<u64>().ok())
                 .unwrap_or_default();
 
             let compute = RE_DRM_ENGINE_COMPUTE
@@ -514,17 +550,16 @@ impl ProcessData {
                 .and_then(|capture| capture.as_str().parse::<u64>().ok())
                 .unwrap_or_default();
 
-            let enc = RE_DRM_ENGINE_ENC // amd
+            let enc = RE_DRM_ENGINE_ENC
                 .captures(&content)
                 .and_then(|captures| captures.get(1))
                 .and_then(|capture| capture.as_str().parse::<u64>().ok())
-                .or_else(|| {
-                    // intel
-                    RE_DRM_ENGINE_VIDEO
-                        .captures(&content)
-                        .and_then(|captures| captures.get(1))
-                        .and_then(|capture| capture.as_str().parse::<u64>().ok())
-                })
+                .unwrap_or_default();
+
+            let video = RE_DRM_ENGINE_VIDEO
+                .captures(&content)
+                .and_then(|captures| captures.get(1))
+                .and_then(|capture| capture.as_str().parse::<u64>().ok())
                 .unwrap_or_default();
 
             let dec = RE_DRM_ENGINE_DEC
@@ -547,26 +582,33 @@ impl ProcessData {
                 .unwrap_or_default()
                 .saturating_mul(1024);
 
+            let total_memory = RE_DRM_TOTAL_MEMORY
+                .captures(&content)
+                .and_then(|captures| captures.get(1))
+                .and_then(|capture| capture.as_str().parse::<u64>().ok())
+                .unwrap_or_default()
+                .saturating_mul(1024);
+
             let stats = GpuUsageStats {
-                gfx: gfx.saturating_add(compute),
-                mem: vram.saturating_add(gtt),
-                enc,
+                gfx: gfx.saturating_add(render).saturating_add(compute),
+                mem: vram.saturating_add(gtt).saturating_add(total_memory),
+                enc: enc.saturating_add(video),
                 dec,
                 nvidia: false,
             };
 
-            return Ok((pci_slot, stats));
+            return Ok((gpu_identifier, stats));
         }
 
         bail!("unable to find gpu information in this fdinfo");
     }
 
-    fn nvidia_gpu_stats_all(pid: i32) -> BTreeMap<PciSlot, GpuUsageStats> {
+    fn nvidia_gpu_stats_all(pid: i32) -> BTreeMap<GpuIdentifier, GpuUsageStats> {
         let mut return_map = BTreeMap::new();
 
         for (pci_slot, _) in NVML_DEVICES.iter() {
             if let Ok(stats) = Self::nvidia_gpu_stats(pid, *pci_slot) {
-                return_map.insert(pci_slot.to_owned(), stats);
+                return_map.insert(GpuIdentifier::PciSlot(pci_slot.to_owned()), stats);
             }
         }
 

--- a/src/ui/pages/gpu.rs
+++ b/src/ui/pages/gpu.rs
@@ -192,7 +192,7 @@ impl ResGPU {
     pub fn setup_widgets(&self, gpu: &Gpu) {
         let imp = self.imp();
 
-        let tab_id = format!("{}-{}", TAB_ID_PREFIX, &gpu.pci_slot().to_string());
+        let tab_id = format!("{}-{}", TAB_ID_PREFIX, &gpu.gpu_identifier());
         imp.set_tab_id(&tab_id);
 
         imp.gpu_usage.set_title_label(&i18n("Total Usage"));
@@ -231,7 +231,12 @@ impl ResGPU {
                 .map_or_else(|_| i18n("N/A"), |vendor| vendor.name().to_string()),
         );
 
-        imp.pci_slot.set_subtitle(&gpu.pci_slot().to_string());
+        match gpu.gpu_identifier() {
+            process_data::GpuIdentifier::PciSlot(pci_slot) => {
+                imp.pci_slot.set_subtitle(&pci_slot.to_string())
+            }
+            process_data::GpuIdentifier::Enumerator(_) => imp.pci_slot.set_subtitle(&i18n("N/A")),
+        }
 
         imp.driver_used.set_subtitle(&gpu.driver());
 
@@ -252,7 +257,7 @@ impl ResGPU {
         let imp = self.imp();
 
         let GpuData {
-            pci_slot: _,
+            gpu_identifier: _,
             usage_fraction,
             encode_fraction,
             decode_fraction,

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -495,7 +495,7 @@ impl MainWindow {
             Process::all_data()
                 .inspect_err(|e| {
                     warn!(
-                        "Unable to update process and app data!\n{e}\n{}",
+                        "Unable to update process and app data! Is resources-processes running?\n{e}\n{}",
                         e.backtrace()
                     );
                 })

--- a/src/utils/app.rs
+++ b/src/utils/app.rs
@@ -12,7 +12,7 @@ use gtk::{
 };
 use lazy_regex::{lazy_regex, Lazy, Regex};
 use log::{debug, info};
-use process_data::{pci_slot::PciSlot, Containerization, ProcessData};
+use process_data::{Containerization, GpuIdentifier, ProcessData};
 
 use crate::i18n::i18n;
 
@@ -163,7 +163,7 @@ static MESSAGE_LOCALES: LazyLock<Vec<String>> = LazyLock::new(|| {
 pub struct AppsContext {
     apps: HashMap<Option<String>, App>,
     processes: HashMap<i32, Process>,
-    gpus_with_combined_media_engine: Vec<PciSlot>,
+    gpus_with_combined_media_engine: Vec<GpuIdentifier>,
 }
 
 /// Represents an application installed on the system. It doesn't
@@ -511,7 +511,7 @@ impl AppsContext {
     /// Creates a new `AppsContext` object, this operation is quite expensive
     /// so try to do it only one time during the lifetime of the program.
     /// Please call `refresh()` immediately after this function.
-    pub fn new(gpus_with_combined_media_engine: Vec<PciSlot>) -> AppsContext {
+    pub fn new(gpus_with_combined_media_engine: Vec<GpuIdentifier>) -> AppsContext {
         let apps: HashMap<Option<String>, App> = App::all()
             .into_iter()
             .map(|app| (app.id.clone(), app))
@@ -524,7 +524,7 @@ impl AppsContext {
         }
     }
 
-    pub fn gpu_fraction(&self, pci_slot: PciSlot) -> f32 {
+    pub fn gpu_fraction(&self, gpu_identifier: GpuIdentifier) -> f32 {
         self.processes_iter()
             .map(|process| {
                 (
@@ -536,8 +536,8 @@ impl AppsContext {
             })
             .map(|(new, old, timestamp, timestamp_last)| {
                 (
-                    new.get(&pci_slot),
-                    old.get(&pci_slot),
+                    new.get(&gpu_identifier),
+                    old.get(&gpu_identifier),
                     timestamp,
                     timestamp_last,
                 )
@@ -562,7 +562,7 @@ impl AppsContext {
             .clamp(0.0, 1.0)
     }
 
-    pub fn encoder_fraction(&self, pci_slot: PciSlot) -> f32 {
+    pub fn encoder_fraction(&self, gpu_identifier: GpuIdentifier) -> f32 {
         self.processes_iter()
             .map(|process| {
                 (
@@ -574,8 +574,8 @@ impl AppsContext {
             })
             .map(|(new, old, timestamp, timestamp_last)| {
                 (
-                    new.get(&pci_slot),
-                    old.get(&pci_slot),
+                    new.get(&gpu_identifier),
+                    old.get(&gpu_identifier),
                     timestamp,
                     timestamp_last,
                 )
@@ -600,7 +600,7 @@ impl AppsContext {
             .clamp(0.0, 1.0)
     }
 
-    pub fn decoder_fraction(&self, pci_slot: PciSlot) -> f32 {
+    pub fn decoder_fraction(&self, gpu_identifier: GpuIdentifier) -> f32 {
         self.processes_iter()
             .map(|process| {
                 (
@@ -612,8 +612,8 @@ impl AppsContext {
             })
             .map(|(new, old, timestamp, timestamp_last)| {
                 (
-                    new.get(&pci_slot),
-                    old.get(&pci_slot),
+                    new.get(&gpu_identifier),
+                    old.get(&gpu_identifier),
                     timestamp,
                     timestamp_last,
                 )

--- a/src/utils/cpu.rs
+++ b/src/utils/cpu.rs
@@ -7,7 +7,7 @@ use std::{
     sync::LazyLock,
 };
 
-const KNOWN_HWMONS: &[&str] = &["rp1_adc", "zenpower", "coretemp", "k10temp"];
+const KNOWN_HWMONS: &[&str] = &["zenpower", "coretemp", "k10temp"];
 
 const KNOWN_THERMAL_ZONES: &[&str] = &["cpu-thermal", "x86_pkg_temp", "acpitz"];
 

--- a/src/utils/cpu.rs
+++ b/src/utils/cpu.rs
@@ -7,9 +7,9 @@ use std::{
     sync::LazyLock,
 };
 
-const KNOWN_HWMONS: &[&str] = &["zenpower", "coretemp", "k10temp"];
+const KNOWN_HWMONS: &[&str] = &["rp1_adc", "zenpower", "coretemp", "k10temp"];
 
-const KNOWN_THERMAL_ZONES: &[&str] = &["x86_pkg_temp", "acpitz"];
+const KNOWN_THERMAL_ZONES: &[&str] = &["cpu-thermal", "x86_pkg_temp", "acpitz"];
 
 static RE_LSCPU_MODEL_NAME: Lazy<Regex> = lazy_regex!(r"Model name:\s*(.*)");
 

--- a/src/utils/gpu/amd.rs
+++ b/src/utils/gpu/amd.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result};
 use lazy_regex::{lazy_regex, Lazy, Regex};
 use log::{debug, warn};
-use process_data::pci_slot::PciSlot;
+use process_data::GpuIdentifier;
 
 use std::{collections::HashMap, path::PathBuf, sync::LazyLock, time::Instant};
 
@@ -24,7 +24,7 @@ static AMDGPU_IDS: LazyLock<HashMap<(u16, u8), String>> = LazyLock::new(|| {
 
 pub struct AmdGpu {
     pub device: Option<&'static Device>,
-    pub pci_slot: PciSlot,
+    pub gpu_identifier: GpuIdentifier,
     pub driver: String,
     sysfs_path: PathBuf,
     first_hwmon_path: Option<PathBuf>,
@@ -34,14 +34,14 @@ pub struct AmdGpu {
 impl AmdGpu {
     pub fn new(
         device: Option<&'static Device>,
-        pci_slot: PciSlot,
+        gpu_identifier: GpuIdentifier,
         driver: String,
         sysfs_path: PathBuf,
         first_hwmon_path: Option<PathBuf>,
     ) -> Self {
         let mut gpu = Self {
             device,
-            pci_slot,
+            gpu_identifier,
             driver,
             sysfs_path,
             first_hwmon_path,
@@ -100,8 +100,8 @@ impl GpuImpl for AmdGpu {
         self.device
     }
 
-    fn pci_slot(&self) -> PciSlot {
-        self.pci_slot
+    fn gpu_identifier(&self) -> GpuIdentifier {
+        self.gpu_identifier
     }
 
     fn driver(&self) -> String {

--- a/src/utils/gpu/mod.rs
+++ b/src/utils/gpu/mod.rs
@@ -2,10 +2,13 @@ mod amd;
 mod intel;
 mod nvidia;
 mod other;
+mod v3d;
 
 use anyhow::{bail, Context, Result};
+use lazy_regex::{lazy_regex, Lazy, Regex};
 use log::{debug, info};
-use process_data::pci_slot::PciSlot;
+use process_data::{pci_slot::PciSlot, GpuIdentifier};
+use v3d::V3dGpu;
 
 use std::{
     path::{Path, PathBuf},
@@ -27,9 +30,11 @@ pub const VID_AMD: u16 = 4098;
 pub const VID_INTEL: u16 = 32902;
 pub const VID_NVIDIA: u16 = 4318;
 
+const RE_CARD_ENUMARATOR: Lazy<Regex> = lazy_regex!(r"(\d+)\/?$");
+
 #[derive(Debug)]
 pub struct GpuData {
-    pub pci_slot: PciSlot,
+    pub gpu_identifier: GpuIdentifier,
 
     pub usage_fraction: Option<f64>,
 
@@ -54,7 +59,7 @@ pub struct GpuData {
 
 impl GpuData {
     pub fn new(gpu: &Gpu) -> Self {
-        let pci_slot = gpu.pci_slot();
+        let gpu_identifier = gpu.gpu_identifier();
 
         let usage_fraction = gpu.usage().map(|usage| usage.clamp(0.0, 1.0)).ok();
 
@@ -77,7 +82,7 @@ impl GpuData {
         let nvidia = matches!(gpu, Gpu::Nvidia(_));
 
         Self {
-            pci_slot,
+            gpu_identifier,
             usage_fraction,
             encode_fraction,
             decode_fraction,
@@ -97,8 +102,9 @@ impl GpuData {
 #[derive(Debug, Clone)]
 pub enum Gpu {
     Amd(AmdGpu),
-    Nvidia(NvidiaGpu),
     Intel(IntelGpu),
+    Nvidia(NvidiaGpu),
+    V3d(V3dGpu),
     Other(OtherGpu),
 }
 
@@ -110,7 +116,7 @@ impl Default for Gpu {
 
 pub trait GpuImpl {
     fn device(&self) -> Option<&'static Device>;
-    fn pci_slot(&self) -> PciSlot;
+    fn gpu_identifier(&self) -> GpuIdentifier;
     fn driver(&self) -> String;
     fn sysfs_path(&self) -> PathBuf;
     fn first_hwmon(&self) -> Option<PathBuf>;
@@ -215,8 +221,8 @@ impl Gpu {
         debug!("Searching for GPUs…");
 
         let mut gpu_vec: Vec<Gpu> = Vec::new();
-        for entry in glob("/sys/class/drm/card?")?.flatten() {
-            if let Ok(gpu) = Self::from_sysfs_path(entry) {
+        for (i, entry) in glob("/sys/class/drm/card?")?.flatten().enumerate() {
+            if let Ok(gpu) = Self::from_sysfs_path(entry, i) {
                 gpu_vec.push(gpu);
             }
         }
@@ -226,8 +232,15 @@ impl Gpu {
         Ok(gpu_vec)
     }
 
-    fn from_sysfs_path<P: AsRef<Path>>(path: P) -> Result<Gpu> {
-        let sysfs_device_path = path.as_ref().join("device");
+    fn from_sysfs_path<P: AsRef<Path>>(path: P, i: usize) -> Result<Gpu> {
+        let path = path.as_ref().to_path_buf();
+        let enumarator = RE_CARD_ENUMARATOR
+            .captures(&path.to_string_lossy())
+            .and_then(|captures| captures.get(1))
+            .and_then(|capture| capture.as_str().parse().ok())
+            .unwrap_or(i);
+
+        let sysfs_device_path = path.join("device");
         let uevent_contents = read_uevent(sysfs_device_path.join("uevent"))?;
 
         let (device, vid, pid) = if let Some(pci_line) = uevent_contents.get("PCI_ID") {
@@ -256,7 +269,13 @@ impl Gpu {
                 .get("PCI_SLOT_NAME")
                 .map_or_else(|| i18n("N/A"), std::string::ToString::to_string),
         )
-        .context("can't turn PCI string to struct")?;
+        .context("can't turn PCI string to struct");
+
+        let gpu_identifier = if let Ok(pci_slot) = pci_slot {
+            GpuIdentifier::PciSlot(pci_slot)
+        } else {
+            GpuIdentifier::Enumerator(enumarator)
+        };
 
         let driver = uevent_contents
             .get("DRIVER")
@@ -267,13 +286,11 @@ impl Gpu {
             bail!("this is a simple framebuffer");
         }
 
-        let path = path.as_ref().to_path_buf();
-
         let (gpu, gpu_category) = if vid == VID_AMD || driver == "amdgpu" {
             (
                 Gpu::Amd(AmdGpu::new(
                     device,
-                    pci_slot,
+                    gpu_identifier,
                     driver,
                     path,
                     hwmon_vec.first().cloned(),
@@ -284,7 +301,7 @@ impl Gpu {
             (
                 Gpu::Intel(IntelGpu::new(
                     device,
-                    pci_slot,
+                    gpu_identifier,
                     driver,
                     path,
                     hwmon_vec.first().cloned(),
@@ -295,18 +312,29 @@ impl Gpu {
             (
                 Gpu::Nvidia(NvidiaGpu::new(
                     device,
-                    pci_slot,
+                    gpu_identifier,
                     driver,
                     path,
                     hwmon_vec.first().cloned(),
                 )),
                 "NVIDIA",
             )
+        } else if driver == "v3d" {
+            (
+                Gpu::V3d(V3dGpu::new(
+                    device,
+                    gpu_identifier,
+                    driver,
+                    path,
+                    hwmon_vec.first().cloned(),
+                )),
+                "v3d",
+            )
         } else {
             (
                 Gpu::Other(OtherGpu::new(
                     device,
-                    pci_slot,
+                    gpu_identifier,
                     driver,
                     path,
                     hwmon_vec.first().cloned(),
@@ -316,9 +344,9 @@ impl Gpu {
         };
 
         info!(
-            "Found GPU \"{}\" (PCI slot: {} · PCI ID: {vid:x}:{pid:x} · Category: {gpu_category})",
+            "Found GPU \"{}\" (Identifier: {} · PCI ID: {vid:x}:{pid:x} · Category: {gpu_category})",
             gpu.name().unwrap_or("<unknown name>".into()),
-            gpu.pci_slot(),
+            gpu.gpu_identifier(),
         );
 
         Ok(gpu)
@@ -327,28 +355,31 @@ impl Gpu {
     pub fn get_vendor(&self) -> Result<&'static Vendor> {
         Ok(match self {
             Gpu::Amd(gpu) => gpu.device(),
-            Gpu::Nvidia(gpu) => gpu.device(),
             Gpu::Intel(gpu) => gpu.device(),
+            Gpu::Nvidia(gpu) => gpu.device(),
+            Gpu::V3d(gpu) => gpu.device(),
             Gpu::Other(gpu) => gpu.device(),
         }
         .context("no device")?
         .vendor())
     }
 
-    pub fn pci_slot(&self) -> PciSlot {
+    pub fn gpu_identifier(&self) -> GpuIdentifier {
         match self {
-            Gpu::Amd(gpu) => gpu.pci_slot(),
-            Gpu::Nvidia(gpu) => gpu.pci_slot(),
-            Gpu::Intel(gpu) => gpu.pci_slot(),
-            Gpu::Other(gpu) => gpu.pci_slot(),
+            Gpu::Amd(gpu) => gpu.gpu_identifier(),
+            Gpu::Intel(gpu) => gpu.gpu_identifier(),
+            Gpu::Nvidia(gpu) => gpu.gpu_identifier(),
+            Gpu::V3d(gpu) => gpu.gpu_identifier(),
+            Gpu::Other(gpu) => gpu.gpu_identifier(),
         }
     }
 
     pub fn driver(&self) -> String {
         match self {
             Gpu::Amd(gpu) => gpu.driver(),
-            Gpu::Nvidia(gpu) => gpu.driver(),
             Gpu::Intel(gpu) => gpu.driver(),
+            Gpu::Nvidia(gpu) => gpu.driver(),
+            Gpu::V3d(gpu) => gpu.driver(),
             Gpu::Other(gpu) => gpu.driver(),
         }
     }
@@ -356,8 +387,9 @@ impl Gpu {
     pub fn name(&self) -> Result<String> {
         match self {
             Gpu::Amd(gpu) => gpu.name(),
-            Gpu::Nvidia(gpu) => gpu.name(),
             Gpu::Intel(gpu) => gpu.name(),
+            Gpu::Nvidia(gpu) => gpu.name(),
+            Gpu::V3d(gpu) => gpu.name(),
             Gpu::Other(gpu) => gpu.name(),
         }
     }
@@ -365,8 +397,9 @@ impl Gpu {
     pub fn usage(&self) -> Result<f64> {
         match self {
             Gpu::Amd(gpu) => gpu.usage(),
-            Gpu::Nvidia(gpu) => gpu.usage(),
             Gpu::Intel(gpu) => gpu.usage(),
+            Gpu::Nvidia(gpu) => gpu.usage(),
+            Gpu::V3d(gpu) => gpu.usage(),
             Gpu::Other(gpu) => gpu.usage(),
         }
     }
@@ -374,8 +407,9 @@ impl Gpu {
     pub fn encode_usage(&self) -> Result<f64> {
         match self {
             Gpu::Amd(gpu) => gpu.encode_usage(),
-            Gpu::Nvidia(gpu) => gpu.encode_usage(),
             Gpu::Intel(gpu) => gpu.encode_usage(),
+            Gpu::Nvidia(gpu) => gpu.encode_usage(),
+            Gpu::V3d(gpu) => gpu.encode_usage(),
             Gpu::Other(gpu) => gpu.encode_usage(),
         }
     }
@@ -383,8 +417,9 @@ impl Gpu {
     pub fn decode_usage(&self) -> Result<f64> {
         match self {
             Gpu::Amd(gpu) => gpu.decode_usage(),
-            Gpu::Nvidia(gpu) => gpu.decode_usage(),
             Gpu::Intel(gpu) => gpu.decode_usage(),
+            Gpu::Nvidia(gpu) => gpu.decode_usage(),
+            Gpu::V3d(gpu) => gpu.decode_usage(),
             Gpu::Other(gpu) => gpu.decode_usage(),
         }
     }
@@ -392,8 +427,9 @@ impl Gpu {
     pub fn combined_media_engine(&self) -> Result<bool> {
         match self {
             Gpu::Amd(gpu) => gpu.combined_media_engine(),
-            Gpu::Nvidia(gpu) => gpu.combined_media_engine(),
             Gpu::Intel(gpu) => gpu.combined_media_engine(),
+            Gpu::Nvidia(gpu) => gpu.combined_media_engine(),
+            Gpu::V3d(gpu) => gpu.combined_media_engine(),
             Gpu::Other(gpu) => gpu.combined_media_engine(),
         }
     }
@@ -401,8 +437,9 @@ impl Gpu {
     pub fn used_vram(&self) -> Result<usize> {
         match self {
             Gpu::Amd(gpu) => gpu.used_vram(),
-            Gpu::Nvidia(gpu) => gpu.used_vram(),
             Gpu::Intel(gpu) => gpu.used_vram(),
+            Gpu::Nvidia(gpu) => gpu.used_vram(),
+            Gpu::V3d(gpu) => gpu.used_vram(),
             Gpu::Other(gpu) => gpu.used_vram(),
         }
     }
@@ -410,8 +447,9 @@ impl Gpu {
     pub fn total_vram(&self) -> Result<usize> {
         match self {
             Gpu::Amd(gpu) => gpu.total_vram(),
-            Gpu::Nvidia(gpu) => gpu.total_vram(),
             Gpu::Intel(gpu) => gpu.total_vram(),
+            Gpu::Nvidia(gpu) => gpu.total_vram(),
+            Gpu::V3d(gpu) => gpu.total_vram(),
             Gpu::Other(gpu) => gpu.total_vram(),
         }
     }
@@ -419,8 +457,9 @@ impl Gpu {
     pub fn temperature(&self) -> Result<f64> {
         match self {
             Gpu::Amd(gpu) => gpu.temperature(),
-            Gpu::Nvidia(gpu) => gpu.temperature(),
             Gpu::Intel(gpu) => gpu.temperature(),
+            Gpu::Nvidia(gpu) => gpu.temperature(),
+            Gpu::V3d(gpu) => gpu.temperature(),
             Gpu::Other(gpu) => gpu.temperature(),
         }
     }
@@ -428,8 +467,9 @@ impl Gpu {
     pub fn power_usage(&self) -> Result<f64> {
         match self {
             Gpu::Amd(gpu) => gpu.power_usage(),
-            Gpu::Nvidia(gpu) => gpu.power_usage(),
             Gpu::Intel(gpu) => gpu.power_usage(),
+            Gpu::Nvidia(gpu) => gpu.power_usage(),
+            Gpu::V3d(gpu) => gpu.power_usage(),
             Gpu::Other(gpu) => gpu.power_usage(),
         }
     }
@@ -437,8 +477,9 @@ impl Gpu {
     pub fn core_frequency(&self) -> Result<f64> {
         match self {
             Gpu::Amd(gpu) => gpu.core_frequency(),
-            Gpu::Nvidia(gpu) => gpu.core_frequency(),
             Gpu::Intel(gpu) => gpu.core_frequency(),
+            Gpu::Nvidia(gpu) => gpu.core_frequency(),
+            Gpu::V3d(gpu) => gpu.core_frequency(),
             Gpu::Other(gpu) => gpu.core_frequency(),
         }
     }
@@ -446,8 +487,9 @@ impl Gpu {
     pub fn vram_frequency(&self) -> Result<f64> {
         match self {
             Gpu::Amd(gpu) => gpu.vram_frequency(),
-            Gpu::Nvidia(gpu) => gpu.vram_frequency(),
             Gpu::Intel(gpu) => gpu.vram_frequency(),
+            Gpu::Nvidia(gpu) => gpu.vram_frequency(),
+            Gpu::V3d(gpu) => gpu.vram_frequency(),
             Gpu::Other(gpu) => gpu.vram_frequency(),
         }
     }
@@ -455,8 +497,9 @@ impl Gpu {
     pub fn power_cap(&self) -> Result<f64> {
         match self {
             Gpu::Amd(gpu) => gpu.power_cap(),
-            Gpu::Nvidia(gpu) => gpu.power_cap(),
             Gpu::Intel(gpu) => gpu.power_cap(),
+            Gpu::Nvidia(gpu) => gpu.power_cap(),
+            Gpu::V3d(gpu) => gpu.power_cap(),
             Gpu::Other(gpu) => gpu.power_cap(),
         }
     }
@@ -464,8 +507,9 @@ impl Gpu {
     pub fn power_cap_max(&self) -> Result<f64> {
         match self {
             Gpu::Amd(gpu) => gpu.power_cap_max(),
-            Gpu::Nvidia(gpu) => gpu.power_cap_max(),
             Gpu::Intel(gpu) => gpu.power_cap_max(),
+            Gpu::Nvidia(gpu) => gpu.power_cap_max(),
+            Gpu::V3d(gpu) => gpu.power_cap_max(),
             Gpu::Other(gpu) => gpu.power_cap_max(),
         }
     }

--- a/src/utils/gpu/nvidia.rs
+++ b/src/utils/gpu/nvidia.rs
@@ -5,7 +5,7 @@ use nvml_wrapper::{
     error::NvmlError,
     Nvml,
 };
-use process_data::pci_slot::PciSlot;
+use process_data::GpuIdentifier;
 
 use std::{path::PathBuf, sync::LazyLock};
 
@@ -29,7 +29,7 @@ use super::GpuImpl;
 
 pub struct NvidiaGpu {
     pub device: Option<&'static Device>,
-    pub pci_slot: PciSlot,
+    pub gpu_identifier: GpuIdentifier,
     pub driver: String,
     pci_slot_string: String,
     sysfs_path: PathBuf,
@@ -39,16 +39,16 @@ pub struct NvidiaGpu {
 impl NvidiaGpu {
     pub fn new(
         device: Option<&'static Device>,
-        pci_slot: PciSlot,
+        gpu_identifier: GpuIdentifier,
         driver: String,
         sysfs_path: PathBuf,
         first_hwmon_path: Option<PathBuf>,
     ) -> Self {
         Self {
             device,
-            pci_slot,
+            gpu_identifier,
             driver,
-            pci_slot_string: pci_slot.to_string(),
+            pci_slot_string: gpu_identifier.to_string(),
             sysfs_path,
             first_hwmon_path,
         }
@@ -69,8 +69,8 @@ impl GpuImpl for NvidiaGpu {
         self.device
     }
 
-    fn pci_slot(&self) -> PciSlot {
-        self.pci_slot
+    fn gpu_identifier(&self) -> GpuIdentifier {
+        self.gpu_identifier
     }
 
     fn driver(&self) -> String {

--- a/src/utils/gpu/other.rs
+++ b/src/utils/gpu/other.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use process_data::pci_slot::PciSlot;
+use process_data::GpuIdentifier;
 
 use std::path::PathBuf;
 
@@ -11,7 +11,7 @@ use super::GpuImpl;
 
 pub struct OtherGpu {
     pub device: Option<&'static Device>,
-    pub pci_slot: PciSlot,
+    pub gpu_identifier: GpuIdentifier,
     pub driver: String,
     sysfs_path: PathBuf,
     first_hwmon_path: Option<PathBuf>,
@@ -20,14 +20,14 @@ pub struct OtherGpu {
 impl OtherGpu {
     pub fn new(
         device: Option<&'static Device>,
-        pci_slot: PciSlot,
+        gpu_identifier: GpuIdentifier,
         driver: String,
         sysfs_path: PathBuf,
         first_hwmon_path: Option<PathBuf>,
     ) -> Self {
         Self {
             device,
-            pci_slot,
+            gpu_identifier,
             driver,
             sysfs_path,
             first_hwmon_path,
@@ -40,8 +40,8 @@ impl GpuImpl for OtherGpu {
         self.device
     }
 
-    fn pci_slot(&self) -> PciSlot {
-        self.pci_slot
+    fn gpu_identifier(&self) -> GpuIdentifier {
+        self.gpu_identifier
     }
 
     fn driver(&self) -> String {

--- a/src/utils/gpu/v3d.rs
+++ b/src/utils/gpu/v3d.rs
@@ -9,7 +9,7 @@ use super::GpuImpl;
 
 #[derive(Debug, Clone, Default)]
 
-pub struct IntelGpu {
+pub struct V3dGpu {
     pub device: Option<&'static Device>,
     pub gpu_identifier: GpuIdentifier,
     pub driver: String,
@@ -17,7 +17,7 @@ pub struct IntelGpu {
     first_hwmon_path: Option<PathBuf>,
 }
 
-impl IntelGpu {
+impl V3dGpu {
     pub fn new(
         device: Option<&'static Device>,
         gpu_identifier: GpuIdentifier,
@@ -35,7 +35,7 @@ impl IntelGpu {
     }
 }
 
-impl GpuImpl for IntelGpu {
+impl GpuImpl for V3dGpu {
     fn device(&self) -> Option<&'static Device> {
         self.device
     }
@@ -65,11 +65,11 @@ impl GpuImpl for IntelGpu {
     }
 
     fn encode_usage(&self) -> Result<f64> {
-        bail!("encode usage not implemented for Intel")
+        bail!("encode usage not implemented for v3d")
     }
 
     fn decode_usage(&self) -> Result<f64> {
-        bail!("decode usage not implemented for Intel")
+        bail!("decode usage not implemented for v3d")
     }
 
     fn combined_media_engine(&self) -> Result<bool> {

--- a/src/utils/process.rs
+++ b/src/utils/process.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Context, Result};
 use config::LIBEXECDIR;
 use log::{debug, error, info};
-use process_data::{pci_slot::PciSlot, GpuUsageStats, Niceness, ProcessData};
+use process_data::{GpuIdentifier, GpuUsageStats, Niceness, ProcessData};
 use std::{
     collections::BTreeMap,
     ffi::{OsStr, OsString},
@@ -68,7 +68,7 @@ pub struct Process {
     pub timestamp_last: u64,
     pub read_bytes_last: Option<u64>,
     pub write_bytes_last: Option<u64>,
-    pub gpu_usage_stats_last: BTreeMap<PciSlot, GpuUsageStats>,
+    pub gpu_usage_stats_last: BTreeMap<GpuIdentifier, GpuUsageStats>,
     pub display_name: String,
 }
 


### PR DESCRIPTION
Adds fdinfo-based monitoring for Raspberry Pi GPUs and CPU temperature.
Requires kernel version ≥ 6.12.0.

Resolves #408.