### PR TITLE
Add support for ivpu memory statistic coming with 6.14

### DIFF
--- a/src/utils/npu/intel.rs
+++ b/src/utils/npu/intel.rs
@@ -83,11 +83,11 @@ impl NpuImpl for IntelNpu {
     }
 
     fn used_vram(&self) -> Result<usize> {
-        self.drm_used_vram().map(|usage| usage as usize)
+        self.drm_used_memory().map(|usage| usage as usize)
     }
 
     fn total_vram(&self) -> Result<usize> {
-        self.drm_total_vram().map(|usage| usage as usize)
+        self.drm_total_memory().map(|usage| usage as usize)
     }
 
     fn temperature(&self) -> Result<f64> {
@@ -103,7 +103,7 @@ impl NpuImpl for IntelNpu {
     }
 
     fn memory_frequency(&self) -> Result<f64> {
-        self.hwmon_vram_frequency()
+        self.hwmon_memory_frequency()
     }
 
     fn power_cap(&self) -> Result<f64> {

--- a/src/utils/npu/mod.rs
+++ b/src/utils/npu/mod.rs
@@ -151,15 +151,20 @@ pub trait NpuImpl {
     }
 
     fn drm_usage(&self) -> Result<isize> {
-        bail!("usage fallback not implemented")
+        // No NPU driver actually implements this yet, this is a guess for the future based on drm_usage() for GPUs
+        self.read_device_int("npu_busy_percent")
     }
 
-    fn drm_used_vram(&self) -> Result<isize> {
-        self.read_device_int("mem_info_vram_used")
+    fn drm_used_memory(&self) -> Result<isize> {
+        // ivpu will implement this with kernel 6.14, using this as a fallback just in case other vendors start using
+        // this name as well
+        self.read_device_int("npu_memory_utilization")
     }
 
-    fn drm_total_vram(&self) -> Result<isize> {
-        self.read_device_int("mem_info_vram_total")
+    fn drm_total_memory(&self) -> Result<isize> {
+        // No NPU driver actually implements this yet, this is a guess for the future based on ivpu's
+        // npu_memory_utilization
+        self.read_device_int("npu_memory_total")
     }
 
     fn hwmon_temperature(&self) -> Result<f64> {
@@ -177,7 +182,7 @@ pub trait NpuImpl {
         Ok(self.read_hwmon_int("freq1_input")? as f64)
     }
 
-    fn hwmon_vram_frequency(&self) -> Result<f64> {
+    fn hwmon_memory_frequency(&self) -> Result<f64> {
         Ok(self.read_hwmon_int("freq2_input")? as f64)
     }
 

--- a/src/utils/npu/other.rs
+++ b/src/utils/npu/other.rs
@@ -65,11 +65,11 @@ impl NpuImpl for OtherNpu {
     }
 
     fn used_vram(&self) -> Result<usize> {
-        self.drm_used_vram().map(|usage| usage as usize)
+        self.drm_used_memory().map(|usage| usage as usize)
     }
 
     fn total_vram(&self) -> Result<usize> {
-        self.drm_total_vram().map(|usage| usage as usize)
+        self.drm_total_memory().map(|usage| usage as usize)
     }
 
     fn temperature(&self) -> Result<f64> {
@@ -85,7 +85,7 @@ impl NpuImpl for OtherNpu {
     }
 
     fn memory_frequency(&self) -> Result<f64> {
-        self.hwmon_vram_frequency()
+        self.hwmon_memory_frequency()
     }
 
     fn power_cap(&self) -> Result<f64> {


### PR DESCRIPTION
Intel seems to add a statistic for memory used by NPUs in kernel 6.14 (https://www.phoronix.com/news/Intel-NPU-Linux-6.14-IVPU).
This PR adds support for it, adds more potential future fallbacks for NPU statistics and allows for the NPU memory graph to also work when there's no total NPU memory statistic.