### PR TITLE
Add fallback for charge calculation when `capacity` sysfs is missing

### DIFF
--- a/src/utils/battery.rs
+++ b/src/utils/battery.rs
@@ -282,7 +282,7 @@ impl Battery {
             });
 
         if let (Ok(energy_now), Ok(energy_full)) = (energy_now, energy_full) {
-            Ok((energy_now as f64 / energy_full as f64 * 100.0) / 100.0)
+            Ok(energy_now as f64 / energy_full as f64)
         } else {
             bail!("no charge from energy information found");
         }

--- a/src/utils/battery.rs
+++ b/src/utils/battery.rs
@@ -282,7 +282,7 @@ impl Battery {
             });
 
         if let (Ok(energy_now), Ok(energy_full)) = (energy_now, energy_full) {
-            Ok((energy_now as f64 / energy_full as f64).ceil())
+            Ok((energy_now as f64 / energy_full as f64 * 100.0) / 100.0)
         } else {
             bail!("no charge from energy information found");
         }


### PR DESCRIPTION
On my Dell XPS 13 9345 Snapdragon X, the `capacity` sysfs file is empty. So Resources doesn't show the charge.
However, Gnome does show proper charge. That charge can be calculated properly from `energy_now`/`energy_full`. So this PR adds logic for that.

My battery doesn't show up in Resources at all by the way, cause the path is `/power_supply/qcom-battmgr-bat`, but that's for another PR. 

This is my first PR on a Rust project, so let me know if there are things missing or whatsoever. 
