### PR TITLE
Handle signed values of power_now

### DIFF
--- a/src/utils/battery.rs
+++ b/src/utils/battery.rs
@@ -310,8 +310,8 @@ impl Battery {
             .context("unable to read power_now file")
             .and_then(|x| {
                 x.trim()
-                    .parse::<usize>()
-                    .map(|microwatts| microwatts as f64 / 1_000_000.0)
+                    .parse::<isize>()
+                    .map(|microwatts| microwatts.abs() as f64 / 1_000_000.0)
                     .context("unable to parse power_now sysfs file")
             })
             .or_else(|_| self.power_usage_from_voltage_and_current())


### PR DESCRIPTION
`power_now` sysfs value can be negative (as is on my Dell XPS 13 9345 when not charging). However Resources parses it as a `usize`, which fails in those cases.

Parse it a `isize` and use `.abs()` on value. (Resources also doesn't allow negative values, something to consider maybe?).
