### PR TITLE
Autodetect relevant batteries instead of relying on hardcoded filenames.

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -15,7 +15,7 @@ jobs:
       options: --privileged
     steps:
       - uses: actions/checkout@v4
-      - uses: jochumdev/flatpak-github-actions/flatpak-builder@builder-update-deps
+      - uses: flathub-infra/flatpak-github-actions/flatpak-builder@master
         with:
           manifest-path: build-aux/net.nokyan.Resources.Devel.json
           run-tests: true


### PR DESCRIPTION
Battery on my Dell XPS 9345 Snapdragon X didn't show up in Resources. Turns out the naming of the battery in `/sys/class/power_supply/` is not `BATx` but a whole different `qcom-battmgr-bat`. So it seems it's not very wise to rely on a hardcoded detection of `^BAT`. 

I did some [research](https://lore.kernel.org/lkml/20230516204114.vv5w2vmcyulmhmm4@mercury.elektranox.org/) and figured out a quite simple way to detect which of the `power_supply/*` items are indeed system batteries and not your Mouse/Keyboard ones. 
```
enumerate /sys/class/power_supply/*    -> conditions: type = "Battery" and scope != "Device"
```
Or to get a quick debug output:
```
for a in /sys/class/power_supply/*; do echo "$a: type: $(cat $a/type) scope: $(cat $a/scope 2>/dev/null)"; done
```

This was tested by a another user with a Dell laptop with a BAT0 entry. I tested it with my Snapdragon laptop. And will try to test it on another laptop as well. But it seems quite solid. Ofcourse, some extra testing would be really nice to see if we regress.

I wanted to add unittests for the logic, but there is no way to mock the `fs` part, and not sure if we want to use a temp filesystem structure. From what I see in the project the sysfs reading logic is not really tested, so I omitted them.