### PR TITLE
Display PCIe link speed for NVME and GPU

### DIFF
--- a/data/resources/ui/pages/drive.ui
+++ b/data/resources/ui/pages/drive.ui
@@ -97,6 +97,15 @@
                         <property name="subtitle-selectable">true</property>
                       </object>
                     </child>
+                    <child>
+                      <object class="AdwActionRow" id="link">
+                        <property name="title" translatable="yes">Link</property>
+                        <style>
+                          <class name="property"/>
+                        </style>
+                        <property name="subtitle-selectable">true</property>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>

--- a/data/resources/ui/pages/gpu.ui
+++ b/data/resources/ui/pages/gpu.ui
@@ -108,6 +108,15 @@
                         <property name="title" translatable="yes">Max Power Cap</property>
                       </object>
                     </child>
+                    <child>
+                      <object class="AdwActionRow" id="link">
+                        <property name="title" translatable="yes">Link</property>
+                        <style>
+                          <class name="property"/>
+                        </style>
+                        <property name="subtitle-selectable">true</property>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>

--- a/po/de.po
+++ b/po/de.po
@@ -1,13 +1,13 @@
 #
 # piekay <>, 2024.
-# nokyan <hello@nokyan.net>, 2022-2024.
+# nokyan <hello@nokyan.net>, 2022-2025.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: resources\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-19 13:51+0200\n"
-"PO-Revision-Date: 2024-10-19 13:57+0200\n"
+"POT-Creation-Date: 2025-02-16 19:23+0100\n"
+"PO-Revision-Date: 2025-02-16 19:23+0100\n"
 "Last-Translator: nokyan <hello@nokyan.net>\n"
 "Language-Team: German <hello@nokyan.net>\n"
 "Language: de\n"
@@ -15,10 +15,10 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"X-Generator: Gtranslator 47.0\n"
+"X-Generator: Gtranslator 47.1\n"
 
 #: data/net.nokyan.Resources.desktop.in.in:3
-#: data/net.nokyan.Resources.metainfo.xml.in.in:4 src/application.rs:262
+#: data/net.nokyan.Resources.metainfo.xml.in.in:4 src/application.rs:265
 #: data/resources/ui/window.ui:22
 msgid "Resources"
 msgstr "Ressourcen"
@@ -56,28 +56,28 @@ msgid "CPU"
 msgstr "CPU"
 
 #: data/net.nokyan.Resources.metainfo.xml.in.in:25
-#: src/ui/pages/applications/mod.rs:811 src/ui/pages/memory.rs:105
-#: src/ui/pages/memory.rs:186 src/ui/pages/processes/mod.rs:1087
-#: data/resources/ui/window.ui:158 data/resources/ui/window.ui:165
+#: src/ui/pages/applications/mod.rs:801 src/ui/pages/memory.rs:106
+#: src/ui/pages/memory.rs:191 src/ui/pages/processes/mod.rs:1077
+#: data/resources/ui/window.ui:176 data/resources/ui/window.ui:183
 #: data/resources/ui/dialogs/app_dialog.ui:82
 #: data/resources/ui/dialogs/process_dialog.ui:64
-#: data/resources/ui/dialogs/settings_dialog.ui:133
-#: data/resources/ui/dialogs/settings_dialog.ui:220
+#: data/resources/ui/dialogs/settings_dialog.ui:128
+#: data/resources/ui/dialogs/settings_dialog.ui:215
 msgid "Memory"
 msgstr "Arbeitsspeicher"
 
 #: data/net.nokyan.Resources.metainfo.xml.in.in:26
-#: src/ui/pages/applications/mod.rs:1184 src/ui/pages/gpu.rs:114
-#: src/ui/pages/processes/mod.rs:1471 src/ui/window.rs:311
+#: src/ui/pages/applications/mod.rs:1174 src/ui/pages/gpu.rs:118
+#: src/ui/pages/processes/mod.rs:1461 src/ui/window.rs:460
 #: data/resources/ui/dialogs/app_dialog.ui:140
 #: data/resources/ui/dialogs/process_dialog.ui:118
-#: data/resources/ui/dialogs/settings_dialog.ui:163
-#: data/resources/ui/dialogs/settings_dialog.ui:250
+#: data/resources/ui/dialogs/settings_dialog.ui:158
+#: data/resources/ui/dialogs/settings_dialog.ui:245
 msgid "GPU"
 msgstr "GPU"
 
 #: data/net.nokyan.Resources.metainfo.xml.in.in:27
-#: data/resources/ui/dialogs/settings_dialog.ui:314
+#: data/resources/ui/dialogs/settings_dialog.ui:309
 msgid "Network Interfaces"
 msgstr "Netzwerkschnittstellen"
 
@@ -121,200 +121,202 @@ msgstr "„Netzwerkschnittstelle“ im hellen Design"
 msgid "Battery page in dark theme"
 msgstr "„Akku“ im dunklen Design"
 
-#: src/application.rs:264
+#: src/application.rs:267
 msgid "The Nalux Team"
 msgstr "Das Nalux-Team"
 
-#: src/application.rs:272
+#: src/application.rs:275
 msgid "Report Issues"
 msgstr "Probleme melden"
 
 #. Translator credits. Replace "translator-credits" with your name/username, and optionally an email or URL.
 #. One name per line, please do not remove previous names.
-#: src/application.rs:278
+#: src/application.rs:281
 msgid "translator-credits"
 msgstr "nokyan <hello@nokyan.net>piekay"
 
-#: src/application.rs:279
+#: src/application.rs:282
 msgid "Icon by"
 msgstr "Icon von"
 
-#: src/ui/dialogs/app_dialog.rs:148 src/ui/dialogs/process_dialog.rs:127
-#: src/ui/dialogs/process_dialog.rs:131 src/ui/dialogs/process_dialog.rs:140
-#: src/ui/dialogs/process_dialog.rs:142 src/ui/dialogs/process_dialog.rs:163
-#: src/ui/dialogs/process_dialog.rs:170 src/ui/dialogs/process_dialog.rs:177
-#: src/ui/dialogs/process_dialog.rs:184 src/ui/pages/applications/mod.rs:954
-#: src/ui/pages/applications/mod.rs:1078 src/ui/pages/battery.rs:196
-#: src/ui/pages/battery.rs:216 src/ui/pages/battery.rs:222
-#: src/ui/pages/battery.rs:225 src/ui/pages/battery.rs:251
-#: src/ui/pages/battery.rs:275 src/ui/pages/battery.rs:277
-#: src/ui/pages/battery.rs:287 src/ui/pages/cpu.rs:218 src/ui/pages/cpu.rs:233
-#: src/ui/pages/cpu.rs:248 src/ui/pages/cpu.rs:254 src/ui/pages/cpu.rs:260
-#: src/ui/pages/cpu.rs:266 src/ui/pages/cpu.rs:270 src/ui/pages/cpu.rs:273
-#: src/ui/pages/cpu.rs:370 src/ui/pages/drive.rs:298 src/ui/pages/drive.rs:329
-#: src/ui/pages/drive.rs:331 src/ui/pages/drive.rs:360
-#: src/ui/pages/drive.rs:362 src/ui/pages/drive.rs:378
-#: src/ui/pages/drive.rs:379 src/ui/pages/drive.rs:386
-#: src/ui/pages/drive.rs:396 src/ui/pages/drive.rs:406 src/ui/pages/gpu.rs:227
-#: src/ui/pages/gpu.rs:267 src/ui/pages/gpu.rs:292 src/ui/pages/gpu.rs:295
-#: src/ui/pages/gpu.rs:306 src/ui/pages/gpu.rs:326 src/ui/pages/gpu.rs:338
-#: src/ui/pages/gpu.rs:352 src/ui/pages/gpu.rs:354 src/ui/pages/gpu.rs:366
-#: src/ui/pages/gpu.rs:373 src/ui/pages/gpu.rs:377 src/ui/pages/memory.rs:221
-#: src/ui/pages/memory.rs:222 src/ui/pages/memory.rs:226
-#: src/ui/pages/memory.rs:227 src/ui/pages/memory.rs:231
-#: src/ui/pages/memory.rs:232 src/ui/pages/memory.rs:260
-#: src/ui/pages/memory.rs:317 src/ui/pages/network.rs:230
+#: src/ui/dialogs/app_dialog.rs:153 src/ui/dialogs/process_dialog.rs:131
+#: src/ui/dialogs/process_dialog.rs:135 src/ui/dialogs/process_dialog.rs:144
+#: src/ui/dialogs/process_dialog.rs:146 src/ui/dialogs/process_dialog.rs:169
+#: src/ui/dialogs/process_dialog.rs:176 src/ui/dialogs/process_dialog.rs:183
+#: src/ui/dialogs/process_dialog.rs:190 src/ui/pages/applications/mod.rs:944
+#: src/ui/pages/applications/mod.rs:1068 src/ui/pages/battery.rs:204
+#: src/ui/pages/battery.rs:224 src/ui/pages/battery.rs:230
+#: src/ui/pages/battery.rs:233 src/ui/pages/battery.rs:264
+#: src/ui/pages/battery.rs:288 src/ui/pages/battery.rs:290
+#: src/ui/pages/battery.rs:300 src/ui/pages/cpu.rs:238 src/ui/pages/cpu.rs:253
+#: src/ui/pages/cpu.rs:272 src/ui/pages/cpu.rs:278 src/ui/pages/cpu.rs:284
+#: src/ui/pages/cpu.rs:290 src/ui/pages/cpu.rs:294 src/ui/pages/cpu.rs:297
+#: src/ui/pages/cpu.rs:420 src/ui/pages/drive.rs:315 src/ui/pages/drive.rs:346
+#: src/ui/pages/drive.rs:348 src/ui/pages/drive.rs:377
+#: src/ui/pages/drive.rs:379 src/ui/pages/drive.rs:395
+#: src/ui/pages/drive.rs:396 src/ui/pages/drive.rs:403
+#: src/ui/pages/drive.rs:413 src/ui/pages/drive.rs:423
+#: src/ui/pages/drive.rs:429 src/ui/pages/gpu.rs:243 src/ui/pages/gpu.rs:250
+#: src/ui/pages/gpu.rs:295 src/ui/pages/gpu.rs:320 src/ui/pages/gpu.rs:323
+#: src/ui/pages/gpu.rs:334 src/ui/pages/gpu.rs:354 src/ui/pages/gpu.rs:366
+#: src/ui/pages/gpu.rs:377 src/ui/pages/gpu.rs:389 src/ui/pages/gpu.rs:396
+#: src/ui/pages/gpu.rs:400 src/ui/pages/gpu.rs:430 src/ui/pages/gpu.rs:436
+#: src/ui/pages/memory.rs:226 src/ui/pages/memory.rs:227
+#: src/ui/pages/memory.rs:231 src/ui/pages/memory.rs:232
+#: src/ui/pages/memory.rs:236 src/ui/pages/memory.rs:237
+#: src/ui/pages/memory.rs:265 src/ui/pages/memory.rs:326
 #: src/ui/pages/network.rs:237 src/ui/pages/network.rs:244
-#: src/ui/pages/network.rs:250 src/ui/pages/network.rs:253
-#: src/ui/pages/network.rs:314 src/ui/pages/network.rs:317
-#: src/ui/pages/network.rs:319 src/ui/pages/network.rs:348
-#: src/ui/pages/network.rs:351 src/ui/pages/network.rs:353
-#: src/ui/pages/npu.rs:201 src/ui/pages/npu.rs:230 src/ui/pages/npu.rs:248
-#: src/ui/pages/npu.rs:260 src/ui/pages/npu.rs:274 src/ui/pages/npu.rs:276
-#: src/ui/pages/npu.rs:288 src/ui/pages/npu.rs:295 src/ui/pages/npu.rs:299
-#: src/ui/pages/processes/mod.rs:1229 src/ui/pages/processes/mod.rs:1295
-#: src/ui/pages/processes/mod.rs:1361 src/ui/pages/processes/mod.rs:1427
-#: src/ui/pages/processes/mod.rs:1909 src/ui/pages/processes/mod.rs:1911
-#: src/utils/battery.rs:136 src/utils/drive.rs:89 src/utils/gpu/mod.rs:274
-#: src/utils/gpu/mod.rs:280 src/utils/npu/mod.rs:241 src/utils/npu/mod.rs:247
+#: src/ui/pages/network.rs:251 src/ui/pages/network.rs:257
+#: src/ui/pages/network.rs:260 src/ui/pages/network.rs:326
+#: src/ui/pages/network.rs:329 src/ui/pages/network.rs:331
+#: src/ui/pages/network.rs:360 src/ui/pages/network.rs:363
+#: src/ui/pages/network.rs:365 src/ui/pages/npu.rs:214 src/ui/pages/npu.rs:249
+#: src/ui/pages/npu.rs:304 src/ui/pages/npu.rs:313 src/ui/pages/npu.rs:325
+#: src/ui/pages/npu.rs:332 src/ui/pages/npu.rs:336 src/ui/pages/npu.rs:357
+#: src/ui/pages/processes/mod.rs:1219 src/ui/pages/processes/mod.rs:1285
+#: src/ui/pages/processes/mod.rs:1351 src/ui/pages/processes/mod.rs:1417
+#: src/ui/pages/processes/mod.rs:1899 src/ui/pages/processes/mod.rs:1901
+#: src/utils/battery.rs:149 src/utils/drive.rs:108 src/utils/gpu/mod.rs:284
+#: src/utils/gpu/mod.rs:296 src/utils/link.rs:99 src/utils/link.rs:150
+#: src/utils/npu/mod.rs:252 src/utils/npu/mod.rs:258
 msgid "N/A"
 msgstr "n. v."
 
-#: src/ui/dialogs/process_options_dialog.rs:141 src/ui/pages/cpu.rs:232
-#: src/ui/pages/cpu.rs:354 src/ui/pages/cpu.rs:358
+#: src/ui/dialogs/process_options_dialog.rs:145 src/ui/pages/cpu.rs:252
+#: src/ui/pages/cpu.rs:391 src/ui/pages/cpu.rs:395
 msgid "CPU {}"
 msgstr "CPU {}"
 
-#: src/ui/pages/applications/application_entry.rs:183 src/ui/pages/drive.rs:393
-#: src/ui/pages/drive.rs:403 src/ui/pages/processes/process_entry.rs:204
+#: src/ui/pages/applications/application_entry.rs:186 src/ui/pages/drive.rs:410
+#: src/ui/pages/drive.rs:420 src/ui/pages/processes/process_entry.rs:207
 msgid "No"
 msgstr "Nein"
 
-#: src/ui/pages/applications/application_entry.rs:184
-#: src/ui/pages/processes/process_entry.rs:205
+#: src/ui/pages/applications/application_entry.rs:187
+#: src/ui/pages/processes/process_entry.rs:208
 msgid "Yes (Flatpak)"
 msgstr "Ja (Flatpak)"
 
-#: src/ui/pages/applications/application_entry.rs:185
-#: src/ui/pages/processes/process_entry.rs:206
+#: src/ui/pages/applications/application_entry.rs:188
+#: src/ui/pages/processes/process_entry.rs:209
 msgid "Yes (Snap)"
 msgstr "Ja (Snap)"
 
-#: src/ui/pages/applications/mod.rs:134 data/resources/ui/window.ui:65
+#: src/ui/pages/applications/mod.rs:131 data/resources/ui/window.ui:65
 #: data/resources/ui/window.ui:72
-#: data/resources/ui/dialogs/settings_dialog.ui:127
+#: data/resources/ui/dialogs/settings_dialog.ui:122
 msgid "Apps"
 msgstr "Anwendungen"
 
 #. -1 because we don't want to count System Processes
-#: src/ui/pages/applications/mod.rs:668
+#: src/ui/pages/applications/mod.rs:658
 msgid "Running Apps: {}"
 msgstr "Laufende Anwendungen: {}"
 
-#: src/ui/pages/applications/mod.rs:708 src/ui/pages/processes/mod.rs:870
+#: src/ui/pages/applications/mod.rs:698 src/ui/pages/processes/mod.rs:860
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: src/ui/pages/applications/mod.rs:754
+#: src/ui/pages/applications/mod.rs:744
 msgid "App"
 msgstr "Anwendung"
 
-#: src/ui/pages/applications/mod.rs:870 src/ui/pages/cpu.rs:122
-#: src/ui/pages/processes/mod.rs:1145 src/ui/window.rs:403
-#: data/resources/ui/window.ui:127 data/resources/ui/window.ui:134
+#: src/ui/pages/applications/mod.rs:860 src/ui/pages/cpu.rs:123
+#: src/ui/pages/processes/mod.rs:1135 src/ui/window.rs:289
+#: data/resources/ui/window.ui:145 data/resources/ui/window.ui:152
 #: data/resources/ui/dialogs/app_dialog.ui:73
 #: data/resources/ui/dialogs/process_dialog.ui:55
-#: data/resources/ui/dialogs/settings_dialog.ui:138
-#: data/resources/ui/dialogs/settings_dialog.ui:225
+#: data/resources/ui/dialogs/settings_dialog.ui:133
+#: data/resources/ui/dialogs/settings_dialog.ui:220
 msgid "Processor"
 msgstr "Prozessor"
 
-#: src/ui/pages/applications/mod.rs:933 src/ui/pages/processes/mod.rs:1208
+#: src/ui/pages/applications/mod.rs:923 src/ui/pages/processes/mod.rs:1198
 #: data/resources/ui/dialogs/app_dialog.ui:100
 #: data/resources/ui/dialogs/process_dialog.ui:78
-#: data/resources/ui/dialogs/settings_dialog.ui:143
-#: data/resources/ui/dialogs/settings_dialog.ui:230
+#: data/resources/ui/dialogs/settings_dialog.ui:138
+#: data/resources/ui/dialogs/settings_dialog.ui:225
 msgid "Drive Read"
 msgstr "Lesevorgänge"
 
-#: src/ui/pages/applications/mod.rs:997 src/ui/pages/processes/mod.rs:1274
+#: src/ui/pages/applications/mod.rs:987 src/ui/pages/processes/mod.rs:1264
 #: data/resources/ui/dialogs/app_dialog.ui:109
 #: data/resources/ui/dialogs/process_dialog.ui:87
-#: data/resources/ui/dialogs/settings_dialog.ui:148
-#: data/resources/ui/dialogs/settings_dialog.ui:235
+#: data/resources/ui/dialogs/settings_dialog.ui:143
+#: data/resources/ui/dialogs/settings_dialog.ui:230
 msgid "Drive Read Total"
 msgstr "Lesevorgänge insgesamt"
 
-#: src/ui/pages/applications/mod.rs:1057 src/ui/pages/processes/mod.rs:1340
+#: src/ui/pages/applications/mod.rs:1047 src/ui/pages/processes/mod.rs:1330
 #: data/resources/ui/dialogs/app_dialog.ui:118
 #: data/resources/ui/dialogs/process_dialog.ui:96
-#: data/resources/ui/dialogs/settings_dialog.ui:153
-#: data/resources/ui/dialogs/settings_dialog.ui:240
+#: data/resources/ui/dialogs/settings_dialog.ui:148
+#: data/resources/ui/dialogs/settings_dialog.ui:235
 msgid "Drive Write"
 msgstr "Schreibvorgänge"
 
-#: src/ui/pages/applications/mod.rs:1123 src/ui/pages/processes/mod.rs:1406
+#: src/ui/pages/applications/mod.rs:1113 src/ui/pages/processes/mod.rs:1396
 #: data/resources/ui/dialogs/app_dialog.ui:127
 #: data/resources/ui/dialogs/process_dialog.ui:105
-#: data/resources/ui/dialogs/settings_dialog.ui:158
-#: data/resources/ui/dialogs/settings_dialog.ui:245
+#: data/resources/ui/dialogs/settings_dialog.ui:153
+#: data/resources/ui/dialogs/settings_dialog.ui:240
 msgid "Drive Write Total"
 msgstr "Schreibvorgänge insgesamt"
 
-#: src/ui/pages/applications/mod.rs:1242 src/ui/pages/processes/mod.rs:1529
+#: src/ui/pages/applications/mod.rs:1232 src/ui/pages/processes/mod.rs:1519
 #: data/resources/ui/dialogs/app_dialog.ui:158
 #: data/resources/ui/dialogs/process_dialog.ui:136
-#: data/resources/ui/dialogs/settings_dialog.ui:173
-#: data/resources/ui/dialogs/settings_dialog.ui:260
+#: data/resources/ui/dialogs/settings_dialog.ui:168
+#: data/resources/ui/dialogs/settings_dialog.ui:255
 msgid "Video Encoder"
 msgstr "Videokodierer"
 
-#: src/ui/pages/applications/mod.rs:1302 src/ui/pages/processes/mod.rs:1589
+#: src/ui/pages/applications/mod.rs:1292 src/ui/pages/processes/mod.rs:1579
 #: data/resources/ui/dialogs/app_dialog.ui:167
 #: data/resources/ui/dialogs/process_dialog.ui:145
-#: data/resources/ui/dialogs/settings_dialog.ui:178
-#: data/resources/ui/dialogs/settings_dialog.ui:265
+#: data/resources/ui/dialogs/settings_dialog.ui:173
+#: data/resources/ui/dialogs/settings_dialog.ui:260
 msgid "Video Decoder"
 msgstr "Videodekodierer"
 
-#: src/ui/pages/applications/mod.rs:1361 src/ui/pages/processes/mod.rs:1649
+#: src/ui/pages/applications/mod.rs:1351 src/ui/pages/processes/mod.rs:1639
 #: data/resources/ui/dialogs/app_dialog.ui:149
 #: data/resources/ui/dialogs/process_dialog.ui:127
-#: data/resources/ui/dialogs/settings_dialog.ui:168
-#: data/resources/ui/dialogs/settings_dialog.ui:255
+#: data/resources/ui/dialogs/settings_dialog.ui:163
+#: data/resources/ui/dialogs/settings_dialog.ui:250
 msgid "Video Memory"
 msgstr "Grafikspeicher"
 
-#: src/ui/pages/applications/mod.rs:1419 src/ui/pages/memory.rs:192
-#: src/ui/pages/processes/mod.rs:1952
+#: src/ui/pages/applications/mod.rs:1409 src/ui/pages/memory.rs:197
+#: src/ui/pages/processes/mod.rs:1942
 #: data/resources/ui/dialogs/app_dialog.ui:91
 #: data/resources/ui/dialogs/process_dialog.ui:73
-#: data/resources/ui/dialogs/settings_dialog.ui:183
-#: data/resources/ui/dialogs/settings_dialog.ui:290
+#: data/resources/ui/dialogs/settings_dialog.ui:178
+#: data/resources/ui/dialogs/settings_dialog.ui:285
 msgid "Swap"
 msgstr "Auslagerungsspeicher"
 
-#: src/ui/pages/applications/mod.rs:1477 src/ui/pages/processes/mod.rs:2009
+#: src/ui/pages/applications/mod.rs:1467 src/ui/pages/processes/mod.rs:1999
 msgid "End {}?"
 msgstr "{} beenden?"
 
-#: src/ui/pages/applications/mod.rs:1478 src/ui/pages/processes/mod.rs:2010
+#: src/ui/pages/applications/mod.rs:1468 src/ui/pages/processes/mod.rs:2000
 msgid "Halt {}?"
 msgstr "{} anhalten?"
 
-#: src/ui/pages/applications/mod.rs:1479 src/ui/pages/processes/mod.rs:2011
+#: src/ui/pages/applications/mod.rs:1469 src/ui/pages/processes/mod.rs:2001
 msgid "Kill {}?"
 msgstr "{} abwürgen?"
 
-#: src/ui/pages/applications/mod.rs:1480 src/ui/pages/processes/mod.rs:2012
+#: src/ui/pages/applications/mod.rs:1470 src/ui/pages/processes/mod.rs:2002
 msgid "Continue {}?"
 msgstr "{} fortsetzen?"
 
-#: src/ui/pages/applications/mod.rs:1486 src/ui/pages/processes/mod.rs:2047
+#: src/ui/pages/applications/mod.rs:1476 src/ui/pages/processes/mod.rs:2037
 msgid "Unsaved work might be lost."
 msgstr "Ungespeicherte Daten könnten verloren gehen."
 
-#: src/ui/pages/applications/mod.rs:1487
+#: src/ui/pages/applications/mod.rs:1477
 msgid ""
 "Halting an app can come with serious risks such as losing data and security "
 "implications. Use with caution."
@@ -322,7 +324,7 @@ msgstr ""
 "Das Anhalten einer Anwendung ist mit Risiken wie dem Verlust von Daten sowie "
 "Sicherheitsproblemen verbunden. Sie sollten vorsichtig sein."
 
-#: src/ui/pages/applications/mod.rs:1488
+#: src/ui/pages/applications/mod.rs:1478
 msgid ""
 "Killing an app can come with serious risks such as losing data and security "
 "implications. Use with caution."
@@ -330,216 +332,221 @@ msgstr ""
 "Das Abwürgen einer Anwendung ist mit Risiken wie dem Verlust von Daten sowie "
 "Sicherheitsproblemen verbunden. Sie sollten vorsichtig sein."
 
-#: src/ui/pages/applications/mod.rs:1495
+#: src/ui/pages/applications/mod.rs:1485
 #: data/resources/ui/pages/applications.ui:22
-#: data/resources/ui/pages/applications.ui:127
+#: data/resources/ui/pages/applications.ui:98
 msgid "End App"
 msgstr "Anwendung beenden"
 
-#: src/ui/pages/applications/mod.rs:1496
+#: src/ui/pages/applications/mod.rs:1486
 #: data/resources/ui/pages/applications.ui:10
 #: data/resources/ui/pages/applications.ui:30
 msgid "Halt App"
 msgstr "Anwendung anhalten"
 
-#: src/ui/pages/applications/mod.rs:1497
+#: src/ui/pages/applications/mod.rs:1487
 #: data/resources/ui/pages/applications.ui:6
 #: data/resources/ui/pages/applications.ui:26
 msgid "Kill App"
 msgstr "Anwendung abwürgen"
 
-#: src/ui/pages/applications/mod.rs:1498
+#: src/ui/pages/applications/mod.rs:1488
 #: data/resources/ui/pages/applications.ui:14
 #: data/resources/ui/pages/applications.ui:34
 msgid "Continue App"
 msgstr "Anwendung fortsetzen"
 
-#: src/ui/pages/battery.rs:101 src/ui/pages/drive.rs:122
+#: src/ui/pages/battery.rs:102 src/ui/pages/drive.rs:126
 msgid "Drive"
 msgstr "Speicher"
 
-#: src/ui/pages/battery.rs:201
+#: src/ui/pages/battery.rs:209
 msgid "Battery Charge"
 msgstr "Akkuladung"
 
-#: src/ui/pages/battery.rs:208 data/resources/ui/pages/gpu.ui:55
+#: src/ui/pages/battery.rs:216 data/resources/ui/pages/gpu.ui:55
 #: data/resources/ui/pages/npu.ui:49
 msgid "Power Usage"
 msgstr "Leistungsaufnahme"
 
-#: src/ui/pages/battery.rs:265 src/ui/pages/drive.rs:323
-#: src/ui/pages/drive.rs:354 src/ui/pages/network.rs:306
-#: src/ui/pages/network.rs:340
+#: src/ui/pages/battery.rs:278 src/ui/pages/cpu.rs:412
+#: src/ui/pages/drive.rs:340 src/ui/pages/drive.rs:371 src/ui/pages/gpu.rs:422
+#: src/ui/pages/network.rs:318 src/ui/pages/network.rs:352
+#: src/ui/pages/npu.rs:300 src/ui/pages/npu.rs:349
 msgid "Highest:"
 msgstr "Höchste:"
 
-#: src/ui/pages/cpu.rs:217 src/ui/pages/gpu.rs:198 src/ui/pages/npu.rs:189
+#: src/ui/pages/cpu.rs:237 src/ui/pages/gpu.rs:210 src/ui/pages/npu.rs:198
 msgid "Total Usage"
 msgstr "Gesamtauslastung"
 
-#: src/ui/pages/drive.rs:224
+#: src/ui/pages/cpu.rs:265 src/ui/pages/gpu.rs:237 src/ui/pages/npu.rs:208
+msgid "Temperature"
+msgstr "Temperatur"
+
+#: src/ui/pages/drive.rs:235
 msgid "Drive Activity"
 msgstr "Speicheraktivität"
 
-#: src/ui/pages/drive.rs:231
+#: src/ui/pages/drive.rs:242
 msgid "Read Speed"
 msgstr "Lesegeschwindigkeit"
 
-#: src/ui/pages/drive.rs:235
+#: src/ui/pages/drive.rs:246
 msgid "Write Speed"
 msgstr "Schreibgeschwindigkeit"
 
-#: src/ui/pages/drive.rs:391 src/ui/pages/drive.rs:401
+#: src/ui/pages/drive.rs:408 src/ui/pages/drive.rs:418
 msgid "Yes"
 msgstr "Ja"
 
 #. Translators: This is an abbreviation for "Read" and "Write". This is displayed in the sidebar so your
 #. translation should preferably be quite short or an abbreviation
-#: src/ui/pages/drive.rs:413
+#: src/ui/pages/drive.rs:436
 msgid "R: {} · W: {}"
 msgstr "L: {} · S: {}"
 
-#: src/ui/pages/gpu.rs:206
+#: src/ui/pages/gpu.rs:218
 msgid "Video Encoder/Decoder Usage"
 msgstr "Videokodierer/Videodekodierer"
 
-#: src/ui/pages/gpu.rs:212
+#: src/ui/pages/gpu.rs:224
 msgid "Video Encoder Usage"
 msgstr "Videokodiererauslastung"
 
-#: src/ui/pages/gpu.rs:217
+#: src/ui/pages/gpu.rs:229
 msgid "Video Decoder Usage"
 msgstr "Videodekodiererauslastung"
 
-#: src/ui/pages/gpu.rs:222
+#: src/ui/pages/gpu.rs:234
 msgid "Video Memory Usage"
 msgstr "Grafikspeicherauslastung"
 
 #. Translators: This will be displayed in the sidebar, please try to keep your translation as short as (or even
 #. shorter than) 'Memory'
-#: src/ui/pages/gpu.rs:385 src/ui/pages/npu.rs:307
+#: src/ui/pages/gpu.rs:408 src/ui/pages/npu.rs:274 src/ui/pages/npu.rs:295
 msgid "Memory: {}"
 msgstr "Speicher: {}"
 
-#: src/ui/pages/memory.rs:256
+#: src/ui/pages/memory.rs:261
 msgid "{} of {}"
 msgstr "{} von {}"
 
-#: src/ui/pages/memory.rs:259
+#: src/ui/pages/memory.rs:264
 msgid "{} MT/s"
 msgstr "{} MT/s"
 
 #. Translators: This will be displayed in the sidebar, so your translation for "Swap" should
 #. preferably be quite short or an abbreviation
-#: src/ui/pages/memory.rs:336
+#: src/ui/pages/memory.rs:345
 msgid "{} / {} · Swap: {} %"
 msgstr "{} / {} · Ausl.: {} %"
 
-#: src/ui/pages/network.rs:114 src/utils/network.rs:128
+#: src/ui/pages/network.rs:115 src/utils/network.rs:136
 msgid "Network Interface"
 msgstr "Netzwerkschnittstelle"
 
-#: src/ui/pages/network.rs:218
+#: src/ui/pages/network.rs:226
 msgid "Receiving"
 msgstr "Empfangen"
 
-#: src/ui/pages/network.rs:222
+#: src/ui/pages/network.rs:230
 msgid "Sending"
 msgstr "Senden"
 
 #. Translators: This is an abbreviation for "Receive" and "Send". This is displayed in the sidebar so
 #. your translation should preferably be quite short or an abbreviation
-#: src/ui/pages/network.rs:363
+#: src/ui/pages/network.rs:375
 msgid "R: {} · S: {}"
 msgstr "E: {} · S: {}"
 
-#: src/ui/pages/npu.rs:105 src/ui/window.rs:343
+#: src/ui/pages/npu.rs:106 src/ui/window.rs:490
 msgid "NPU"
 msgstr "NPU"
 
-#: src/ui/pages/npu.rs:196
+#: src/ui/pages/npu.rs:205
 msgid "Memory Usage"
 msgstr "Speicherauslastung"
 
-#: src/ui/pages/processes/mod.rs:178 data/resources/ui/window.ui:96
-#: data/resources/ui/window.ui:103
-#: data/resources/ui/dialogs/settings_dialog.ui:193
+#: src/ui/pages/processes/mod.rs:175 data/resources/ui/window.ui:105
+#: data/resources/ui/window.ui:112
+#: data/resources/ui/dialogs/settings_dialog.ui:188
 msgid "Processes"
 msgstr "Prozesse"
 
-#: src/ui/pages/processes/mod.rs:523 src/ui/pages/processes/mod.rs:2056
+#: src/ui/pages/processes/mod.rs:521 src/ui/pages/processes/mod.rs:2046
 #: data/resources/ui/pages/processes.ui:38
-#: data/resources/ui/pages/processes.ui:186
+#: data/resources/ui/pages/processes.ui:157
 msgid "End Process"
 msgstr "Prozess beenden"
 
-#: src/ui/pages/processes/mod.rs:527 data/resources/ui/pages/processes.ui:70
+#: src/ui/pages/processes/mod.rs:525 data/resources/ui/pages/processes.ui:70
 msgid "End Processes"
 msgstr "Prozesse beenden"
 
-#: src/ui/pages/processes/mod.rs:821
+#: src/ui/pages/processes/mod.rs:811
 msgid "Running Processes: {}"
 msgstr "Laufende Prozesse: {}"
 
-#: src/ui/pages/processes/mod.rs:919
+#: src/ui/pages/processes/mod.rs:909
 msgid "Process"
 msgstr "Prozess"
 
-#: src/ui/pages/processes/mod.rs:980
+#: src/ui/pages/processes/mod.rs:970
 #: data/resources/ui/dialogs/process_dialog.ui:186
-#: data/resources/ui/dialogs/settings_dialog.ui:210
+#: data/resources/ui/dialogs/settings_dialog.ui:205
 msgid "Process ID"
 msgstr "Prozess-ID"
 
-#: src/ui/pages/processes/mod.rs:1033
+#: src/ui/pages/processes/mod.rs:1023
 #: data/resources/ui/dialogs/process_dialog.ui:213
-#: data/resources/ui/dialogs/settings_dialog.ui:215
+#: data/resources/ui/dialogs/settings_dialog.ui:210
 msgid "User"
 msgstr "Benutzer"
 
-#: src/ui/pages/processes/mod.rs:1708
+#: src/ui/pages/processes/mod.rs:1698
 #: data/resources/ui/dialogs/process_dialog.ui:154
-#: data/resources/ui/dialogs/settings_dialog.ui:270
+#: data/resources/ui/dialogs/settings_dialog.ui:265
 msgid "Total CPU Time"
 msgstr "Gesamte Prozessorzeit"
 
-#: src/ui/pages/processes/mod.rs:1767
+#: src/ui/pages/processes/mod.rs:1757
 #: data/resources/ui/dialogs/process_dialog.ui:163
-#: data/resources/ui/dialogs/settings_dialog.ui:275
+#: data/resources/ui/dialogs/settings_dialog.ui:270
 msgid "User CPU Time"
 msgstr "Benutzerprozessorzeit"
 
-#: src/ui/pages/processes/mod.rs:1826
+#: src/ui/pages/processes/mod.rs:1816
 #: data/resources/ui/dialogs/process_dialog.ui:172
-#: data/resources/ui/dialogs/settings_dialog.ui:280
+#: data/resources/ui/dialogs/settings_dialog.ui:275
 msgid "System CPU Time"
 msgstr "Systemprozessorzeit"
 
-#: src/ui/pages/processes/mod.rs:1885
+#: src/ui/pages/processes/mod.rs:1875
 #: data/resources/ui/dialogs/process_options_dialog.ui:87
-#: data/resources/ui/dialogs/settings_dialog.ui:285
+#: data/resources/ui/dialogs/settings_dialog.ui:280
 msgid "Priority"
 msgstr "Priorität"
 
-#: src/ui/pages/processes/mod.rs:2019
+#: src/ui/pages/processes/mod.rs:2009
 msgid "End process?"
 msgid_plural "End {} processes?"
 msgstr[0] "Prozess beenden?"
 msgstr[1] "{} Prozesse beenden?"
 
-#: src/ui/pages/processes/mod.rs:2025
+#: src/ui/pages/processes/mod.rs:2015
 msgid "Halt process?"
 msgid_plural "Halt {} processes?"
 msgstr[0] "Prozess anhalten?"
 msgstr[1] "{} Prozesse anhalten?"
 
-#: src/ui/pages/processes/mod.rs:2031 src/ui/pages/processes/mod.rs:2037
+#: src/ui/pages/processes/mod.rs:2021 src/ui/pages/processes/mod.rs:2027
 msgid "Kill process?"
 msgid_plural "Kill {} processes?"
 msgstr[0] "Prozess abwürgen?"
 msgstr[1] "{} Prozesse abwürgen?"
 
-#: src/ui/pages/processes/mod.rs:2048
+#: src/ui/pages/processes/mod.rs:2038
 msgid ""
 "Halting a process can come with serious risks such as losing data and "
 "security implications. Use with caution."
@@ -547,7 +554,7 @@ msgstr ""
 "Das Anhalten eines Prozesses ist mit Risiken wie dem Verlust von Daten sowie "
 "Sicherheitsproblemen verbunden. Sie sollten vorsichtig sein."
 
-#: src/ui/pages/processes/mod.rs:2049
+#: src/ui/pages/processes/mod.rs:2039
 msgid ""
 "Killing a process can come with serious risks such as losing data and "
 "security implications. Use with caution."
@@ -555,114 +562,114 @@ msgstr ""
 "Das Abwürgen eines Prozesses ist mit Risiken wie dem Verlust von Daten sowie "
 "Sicherheitsproblemen verbunden. Sie sollten vorsichtig sein."
 
-#: src/ui/pages/processes/mod.rs:2057 data/resources/ui/pages/processes.ui:10
+#: src/ui/pages/processes/mod.rs:2047 data/resources/ui/pages/processes.ui:10
 #: data/resources/ui/pages/processes.ui:46
 msgid "Halt Process"
 msgstr "Prozess anhalten"
 
-#: src/ui/pages/processes/mod.rs:2058 data/resources/ui/pages/processes.ui:6
+#: src/ui/pages/processes/mod.rs:2048 data/resources/ui/pages/processes.ui:6
 #: data/resources/ui/pages/processes.ui:42
 msgid "Kill Process"
 msgstr "Prozess abwürgen"
 
-#: src/ui/pages/processes/mod.rs:2059 data/resources/ui/pages/processes.ui:14
+#: src/ui/pages/processes/mod.rs:2049 data/resources/ui/pages/processes.ui:14
 #: data/resources/ui/pages/processes.ui:50
 msgid "Continue Process"
 msgstr "Prozess fortsetzen"
 
-#: src/ui/window.rs:309
+#: src/ui/window.rs:458
 msgid "GPU {}"
 msgstr "GPU {}"
 
-#: src/ui/window.rs:341
+#: src/ui/window.rs:488
 msgid "NPU {}"
 msgstr "NPU {}"
 
-#: src/ui/window.rs:1039
+#: src/ui/window.rs:1154
 msgid "Successfully adjusted {}"
 msgstr "{} wurde erfolgreich angepasst"
 
-#: src/ui/window.rs:1040
+#: src/ui/window.rs:1155
 msgid "There was a problem adjusting {}"
 msgstr "Es gab ein Problem beim Anpassen von {}"
 
-#: src/ui/window.rs:1120
+#: src/ui/window.rs:1237
 msgid "Successfully ended {}"
 msgstr "{} wurde erfolgreich beendet"
 
-#: src/ui/window.rs:1121
+#: src/ui/window.rs:1238
 msgid "Successfully halted {}"
 msgstr "{} wurde erfolgreich angehalten"
 
-#: src/ui/window.rs:1122
+#: src/ui/window.rs:1239
 msgid "Successfully killed {}"
 msgstr "{} wurde erfolgreich abgewürgt"
 
-#: src/ui/window.rs:1123
+#: src/ui/window.rs:1240
 msgid "Successfully continued {}"
 msgstr "{} wurde erfolgreich fortgesetzt"
 
-#: src/ui/window.rs:1130
+#: src/ui/window.rs:1247
 msgid "Successfully ended the process"
 msgid_plural "Successfully ended {} processes"
 msgstr[0] "Prozess wurde erfolgreich beendet"
 msgstr[1] "{} Prozesse wurden erfolgreich beendet"
 
-#: src/ui/window.rs:1136
+#: src/ui/window.rs:1253
 msgid "Successfully halted the process"
 msgid_plural "Successfully halted {} processes"
 msgstr[0] "Prozess wurde erfolgreich angehalten"
 msgstr[1] "{} Prozesse wurden erfolgreich angehalten"
 
-#: src/ui/window.rs:1142
+#: src/ui/window.rs:1259
 msgid "Successfully killed the process"
 msgid_plural "Successfully killed {} processes"
 msgstr[0] "Prozess wurde erfolgreich abgewürgt"
 msgstr[1] "{} Prozesse wurden erfolgreich abgewürgt"
 
-#: src/ui/window.rs:1148
+#: src/ui/window.rs:1265
 msgid "Successfully continued the process"
 msgid_plural "Successfully continued {} processes"
 msgstr[0] "Prozess wurde erfolgreich fortgesetzt"
 msgstr[1] "{} Prozesse wurden erfolgreich fortgesetzt"
 
-#: src/ui/window.rs:1159
+#: src/ui/window.rs:1276
 msgid "There was a problem ending a process"
 msgid_plural "There were problems ending {} processes"
 msgstr[0] "Es gab ein Problem beim Beenden von {} Prozessen"
 msgstr[1] "Es gab ein Problem beim Beenden eines Prozesses"
 
-#: src/ui/window.rs:1165
+#: src/ui/window.rs:1282
 msgid "There was a problem halting a process"
 msgid_plural "There were problems halting {} processes"
 msgstr[0] "Es gab ein Problem beim Anhalten von {} Prozessen"
 msgstr[1] "Es gab ein Problem beim Anhalten eines Prozesses"
 
-#: src/ui/window.rs:1171
+#: src/ui/window.rs:1288
 msgid "There was a problem killing a process"
 msgid_plural "There were problems killing {} processes"
 msgstr[0] "Es gab ein Problem beim Abwürgen von {} Prozessen"
 msgstr[1] "Es gab ein Problem beim Abwürgen eines Prozesses"
 
-#: src/ui/window.rs:1177
+#: src/ui/window.rs:1294
 msgid "There was a problem continuing a process"
 msgid_plural "There were problems continuing {} processes"
 msgstr[0] "Es gab ein Problem beim Fortsetzen von {} Prozessen"
 msgstr[1] "Es gab ein Problem beim Fortsetzen eines Prozesses"
 
-#: src/ui/window.rs:1187
+#: src/ui/window.rs:1304
 msgid "There was a problem ending {}"
 msgstr "Es gab ein Problem beim Beenden von {}"
 
-#: src/ui/window.rs:1188
+#: src/ui/window.rs:1305
 msgid "There was a problem halting {}"
 msgstr "Es gab ein Problem beim Anhalten von {}"
 
-#: src/ui/window.rs:1189
+#: src/ui/window.rs:1306
 msgid "There was a problem killing {}"
 msgstr "Es gab ein Problem beim Abwürgen von {}"
 
-#: src/ui/window.rs:1190
+#: src/ui/window.rs:1307
 msgid "There was a problem continuing {}"
 msgstr "Es gab ein Problem beim Fortsetzen von {}"
 
@@ -670,588 +677,588 @@ msgstr "Es gab ein Problem beim Fortsetzen von {}"
 msgid "System Processes"
 msgstr "Systemprozesse"
 
-#: src/utils/battery.rs:77
+#: src/utils/battery.rs:90
 msgid "Charging"
 msgstr "Lädt"
 
-#: src/utils/battery.rs:78
+#: src/utils/battery.rs:91
 msgid "Discharging"
 msgstr "Entlädt"
 
-#: src/utils/battery.rs:79
+#: src/utils/battery.rs:92
 msgid "Empty"
 msgstr "Leer"
 
-#: src/utils/battery.rs:80
+#: src/utils/battery.rs:93
 msgid "Full"
 msgstr "Voll"
 
-#: src/utils/battery.rs:81
+#: src/utils/battery.rs:94
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: src/utils/battery.rs:127
+#: src/utils/battery.rs:140
 msgid "Nickel-Metal Hydride"
 msgstr "Nickel-Metallhydrid"
 
-#: src/utils/battery.rs:128
+#: src/utils/battery.rs:141
 msgid "Nickel-Cadmium"
 msgstr "Nickel-Cadmium"
 
-#: src/utils/battery.rs:129
+#: src/utils/battery.rs:142
 msgid "Nickel-Zinc"
 msgstr "Nickel-Zink"
 
-#: src/utils/battery.rs:130
+#: src/utils/battery.rs:143
 msgid "Lead-Acid"
 msgstr "Blei"
 
-#: src/utils/battery.rs:131
+#: src/utils/battery.rs:144
 msgid "Lithium-Ion"
 msgstr "Lithium-Ionen"
 
-#: src/utils/battery.rs:132
+#: src/utils/battery.rs:145
 msgid "Lithium Iron Phosphate"
 msgstr "Lithium-Eisenphosphat"
 
-#: src/utils/battery.rs:133
+#: src/utils/battery.rs:146
 msgid "Lithium Polymer"
 msgstr "Lithium-Polymer"
 
-#: src/utils/battery.rs:135
+#: src/utils/battery.rs:148
 msgid "Rechargeable Alkaline Managanese"
 msgstr "Wiederaufladbares Alkali-Mangan"
 
-#: src/utils/battery.rs:229
+#: src/utils/battery.rs:258
 msgid "{} Battery"
 msgstr "{}-Akku"
 
-#: src/utils/battery.rs:231
+#: src/utils/battery.rs:260
 msgid "Battery"
 msgstr "Akku"
 
-#: src/utils/drive.rs:81 src/utils/drive.rs:152
+#: src/utils/drive.rs:100 src/utils/drive.rs:179
 msgid "CD/DVD/Blu-ray Drive"
 msgstr "CD/DVD/Blu-ray-Laufwerk"
 
-#: src/utils/drive.rs:82
+#: src/utils/drive.rs:101
 msgid "eMMC Storage"
 msgstr "eMMC-Speicher"
 
-#: src/utils/drive.rs:83
+#: src/utils/drive.rs:102
 msgid "Flash Storage"
 msgstr "Flash-Speicher"
 
-#: src/utils/drive.rs:84 src/utils/drive.rs:153
+#: src/utils/drive.rs:103 src/utils/drive.rs:180
 msgid "Floppy Drive"
 msgstr "Diskettenlaufwerk"
 
-#: src/utils/drive.rs:85
+#: src/utils/drive.rs:104
 msgid "Hard Disk Drive"
 msgstr "Festplatte"
 
-#: src/utils/drive.rs:86
+#: src/utils/drive.rs:105
 msgid "Loop Device"
 msgstr "Loop Device"
 
-#: src/utils/drive.rs:87
+#: src/utils/drive.rs:106
 msgid "Mapped Device"
 msgstr "Mapped Device"
 
-#: src/utils/drive.rs:88
+#: src/utils/drive.rs:107
 msgid "NVMe Drive"
 msgstr "NVMe-Speicher"
 
-#: src/utils/drive.rs:90
+#: src/utils/drive.rs:109
 msgid "Software Raid"
 msgstr "Software-RAID"
 
-#: src/utils/drive.rs:91
+#: src/utils/drive.rs:110
 msgid "RAM Disk"
 msgstr "RAM-Disk"
 
-#: src/utils/drive.rs:92
+#: src/utils/drive.rs:111
 msgid "Solid State Drive"
 msgstr "Solid-State-Drive"
 
-#: src/utils/drive.rs:93
+#: src/utils/drive.rs:112
 msgid "ZFS Volume"
 msgstr "ZFS-Datenträger"
 
-#: src/utils/drive.rs:94
+#: src/utils/drive.rs:113
 msgid "Compressed RAM Disk (zram)"
 msgstr "Komprimierte RAM-Disk (zram)"
 
-#: src/utils/drive.rs:154
+#: src/utils/drive.rs:181
 msgid "{} Loop Device"
 msgstr "{} Loop Device"
 
-#: src/utils/drive.rs:155
+#: src/utils/drive.rs:182
 msgid "{} Mapped Device"
 msgstr "{} Mapped Device"
 
-#: src/utils/drive.rs:156
+#: src/utils/drive.rs:183
 msgid "{} RAID"
 msgstr "{}-RAID"
 
-#: src/utils/drive.rs:157
+#: src/utils/drive.rs:184
 msgid "{} RAM Disk"
 msgstr "{}-RAM-Disk"
 
-#: src/utils/drive.rs:158
+#: src/utils/drive.rs:185
 msgid "{} zram Device"
 msgstr "{}-zram-Speicher"
 
-#: src/utils/drive.rs:159
+#: src/utils/drive.rs:186
 msgid "{} ZFS Volume"
 msgstr "{}-ZFS-Volumen"
 
-#: src/utils/drive.rs:160
+#: src/utils/drive.rs:187
 msgid "{} Drive"
 msgstr "{}-Datenträger"
 
-#: src/utils/network.rs:116
+#: src/utils/network.rs:124
 msgid "Bluetooth Tether"
 msgstr "Bluetooth-Tether"
 
-#: src/utils/network.rs:117
+#: src/utils/network.rs:125
 msgid "Network Bridge"
 msgstr "Netzwerk-Bridge"
 
-#: src/utils/network.rs:118
+#: src/utils/network.rs:126
 msgid "Ethernet Connection"
 msgstr "Ethernet-Verbindung"
 
-#: src/utils/network.rs:119
+#: src/utils/network.rs:127
 msgid "Docker Bridge"
 msgstr "Docker-Bridge"
 
-#: src/utils/network.rs:120
+#: src/utils/network.rs:128
 msgid "InfiniBand Connection"
 msgstr "InfiniBand-Verbindung"
 
-#: src/utils/network.rs:121
+#: src/utils/network.rs:129
 msgid "Serial Line IP Connection"
 msgstr "Serial-Line-IP-Verbindung"
 
-#: src/utils/network.rs:122
+#: src/utils/network.rs:130
 msgid "Virtual Ethernet Device"
 msgstr "Virtuelles Ethernet-Gerät"
 
-#: src/utils/network.rs:123
+#: src/utils/network.rs:131
 msgid "VM Network Bridge"
 msgstr "VM-Netzwerk-Bridge"
 
-#: src/utils/network.rs:124
+#: src/utils/network.rs:132
 msgid "VPN Tunnel"
 msgstr "VPN-Tunnel"
 
-#: src/utils/network.rs:125
+#: src/utils/network.rs:133
 msgid "VPN Tunnel (WireGuard)"
 msgstr "VPN-Tunnel (WireGuard)"
 
-#: src/utils/network.rs:126
+#: src/utils/network.rs:134
 msgid "Wi-Fi Connection"
 msgstr "WLAN-Verbindung"
 
-#: src/utils/network.rs:127
+#: src/utils/network.rs:135
 msgid "WWAN Connection"
 msgstr "WWAN-Verbindung"
 
-#: src/utils/units.rs:59
+#: src/utils/units.rs:76
 msgid "{} K"
 msgstr "{} K"
 
-#: src/utils/units.rs:61
+#: src/utils/units.rs:78
 msgid "{} °C"
 msgstr "{} °C"
 
-#: src/utils/units.rs:63
+#: src/utils/units.rs:80
 msgid "{} °F"
 msgstr "{} °F"
 
-#: src/utils/units.rs:81 src/utils/units.rs:95 src/utils/units.rs:115
-#: src/utils/units.rs:129
+#: src/utils/units.rs:98 src/utils/units.rs:112 src/utils/units.rs:132
+#: src/utils/units.rs:146
 msgid "{} B"
 msgstr "{} B"
 
-#: src/utils/units.rs:82 src/utils/units.rs:96
+#: src/utils/units.rs:99 src/utils/units.rs:113
 msgid "{} kB"
 msgstr "{} kB"
 
-#: src/utils/units.rs:83 src/utils/units.rs:97
+#: src/utils/units.rs:100 src/utils/units.rs:114
 msgid "{} MB"
 msgstr "{} MB"
 
-#: src/utils/units.rs:84 src/utils/units.rs:98
+#: src/utils/units.rs:101 src/utils/units.rs:115
 msgid "{} GB"
 msgstr "{} GB"
 
-#: src/utils/units.rs:85 src/utils/units.rs:99
+#: src/utils/units.rs:102 src/utils/units.rs:116
 msgid "{} TB"
 msgstr "{} TB"
 
-#: src/utils/units.rs:86 src/utils/units.rs:100
+#: src/utils/units.rs:103 src/utils/units.rs:117
 msgid "{} PB"
 msgstr "{} PB"
 
-#: src/utils/units.rs:87 src/utils/units.rs:101
+#: src/utils/units.rs:104 src/utils/units.rs:118
 msgid "{} EB"
 msgstr "{} EB"
 
-#: src/utils/units.rs:88 src/utils/units.rs:102
+#: src/utils/units.rs:105 src/utils/units.rs:119
 msgid "{} ZB"
 msgstr "{} ZB"
 
-#: src/utils/units.rs:89 src/utils/units.rs:103
+#: src/utils/units.rs:106 src/utils/units.rs:120
 msgid "{} YB"
 msgstr "{} YB"
 
-#: src/utils/units.rs:90 src/utils/units.rs:104
+#: src/utils/units.rs:107 src/utils/units.rs:121
 msgid "{} RB"
 msgstr "{} RB"
 
-#: src/utils/units.rs:91 src/utils/units.rs:105
+#: src/utils/units.rs:108 src/utils/units.rs:122
 msgid "{} QB"
 msgstr "{} QB"
 
-#: src/utils/units.rs:116 src/utils/units.rs:130
+#: src/utils/units.rs:133 src/utils/units.rs:147
 msgid "{} KiB"
 msgstr "{} KiB"
 
-#: src/utils/units.rs:117 src/utils/units.rs:131
+#: src/utils/units.rs:134 src/utils/units.rs:148
 msgid "{} MiB"
 msgstr "{} MiB"
 
-#: src/utils/units.rs:118 src/utils/units.rs:132
+#: src/utils/units.rs:135 src/utils/units.rs:149
 msgid "{} GiB"
 msgstr "{} GiB"
 
-#: src/utils/units.rs:119 src/utils/units.rs:133
+#: src/utils/units.rs:136 src/utils/units.rs:150
 msgid "{} TiB"
 msgstr "{} TiB"
 
-#: src/utils/units.rs:120 src/utils/units.rs:134
+#: src/utils/units.rs:137 src/utils/units.rs:151
 msgid "{} PiB"
 msgstr "{} PiB"
 
-#: src/utils/units.rs:121 src/utils/units.rs:135
+#: src/utils/units.rs:138 src/utils/units.rs:152
 msgid "{} EiB"
 msgstr "{} EiB"
 
-#: src/utils/units.rs:122 src/utils/units.rs:136
+#: src/utils/units.rs:139 src/utils/units.rs:153
 msgid "{} ZiB"
 msgstr "{} ZiB"
 
-#: src/utils/units.rs:123 src/utils/units.rs:137
+#: src/utils/units.rs:140 src/utils/units.rs:154
 msgid "{} YiB"
 msgstr "{} YiB"
 
-#: src/utils/units.rs:124 src/utils/units.rs:138
+#: src/utils/units.rs:141 src/utils/units.rs:155
 msgid "{} RiB"
 msgstr "{} RiB"
 
-#: src/utils/units.rs:125 src/utils/units.rs:139
+#: src/utils/units.rs:142 src/utils/units.rs:156
 msgid "{} QiB"
 msgstr "{} QiB"
 
-#: src/utils/units.rs:166 src/utils/units.rs:183
+#: src/utils/units.rs:183 src/utils/units.rs:200
 msgid "{} B/s"
 msgstr "{} B/s"
 
-#: src/utils/units.rs:167
+#: src/utils/units.rs:184
 msgid "{} kB/s"
 msgstr "{} kB/s"
 
-#: src/utils/units.rs:168
+#: src/utils/units.rs:185
 msgid "{} MB/s"
 msgstr "{} MB/s"
 
-#: src/utils/units.rs:169
+#: src/utils/units.rs:186
 msgid "{} GB/s"
 msgstr "{} GB/s"
 
-#: src/utils/units.rs:170
+#: src/utils/units.rs:187
 msgid "{} TB/s"
 msgstr "{} TB/s"
 
-#: src/utils/units.rs:171
+#: src/utils/units.rs:188
 msgid "{} PB/s"
 msgstr "{} PB/s"
 
-#: src/utils/units.rs:172
+#: src/utils/units.rs:189
 msgid "{} EB/s"
 msgstr "{} EB/s"
 
-#: src/utils/units.rs:173
+#: src/utils/units.rs:190
 msgid "{} ZB/s"
 msgstr "{} ZB/s"
 
-#: src/utils/units.rs:174
+#: src/utils/units.rs:191
 msgid "{} YB/s"
 msgstr "{} YB/s"
 
-#: src/utils/units.rs:175
+#: src/utils/units.rs:192
 msgid "{} RB/s"
 msgstr "{} RB/s"
 
-#: src/utils/units.rs:176
+#: src/utils/units.rs:193
 msgid "{} QB/s"
 msgstr "{} QB/s"
 
-#: src/utils/units.rs:184
+#: src/utils/units.rs:201
 msgid "{} KiB/s"
 msgstr "{} KiB/s"
 
-#: src/utils/units.rs:185
+#: src/utils/units.rs:202
 msgid "{} MiB/s"
 msgstr "{} MiB/s"
 
-#: src/utils/units.rs:186
+#: src/utils/units.rs:203
 msgid "{} GiB/s"
 msgstr "{} GiB/s"
 
-#: src/utils/units.rs:187
+#: src/utils/units.rs:204
 msgid "{} TiB/s"
 msgstr "{} TiB/s"
 
-#: src/utils/units.rs:188
+#: src/utils/units.rs:205
 msgid "{} PiB/s"
 msgstr "{} PiB/s"
 
-#: src/utils/units.rs:189
+#: src/utils/units.rs:206
 msgid "{} EiB/s"
 msgstr "{} EiB/s"
 
-#: src/utils/units.rs:190
+#: src/utils/units.rs:207
 msgid "{} ZiB/s"
 msgstr "{} ZiB/s"
 
-#: src/utils/units.rs:191
+#: src/utils/units.rs:208
 msgid "{} YiB/s"
 msgstr "{} YiB/s"
 
-#: src/utils/units.rs:192
+#: src/utils/units.rs:209
 msgid "{} RiB/s"
 msgstr "{} RiB/s"
 
-#: src/utils/units.rs:193
+#: src/utils/units.rs:210
 msgid "{} QiB/s"
 msgstr "{} QiB/s"
 
-#: src/utils/units.rs:200 src/utils/units.rs:217
+#: src/utils/units.rs:217 src/utils/units.rs:234
 msgid "{} b/s"
 msgstr "{} b/s"
 
-#: src/utils/units.rs:201
+#: src/utils/units.rs:218
 msgid "{} kb/s"
 msgstr "{} kb/s"
 
-#: src/utils/units.rs:202
+#: src/utils/units.rs:219
 msgid "{} Mb/s"
 msgstr "{} Mb/s"
 
-#: src/utils/units.rs:203
+#: src/utils/units.rs:220
 msgid "{} Gb/s"
 msgstr "{} Gb/s"
 
-#: src/utils/units.rs:204
+#: src/utils/units.rs:221
 msgid "{} Tb/s"
 msgstr "{} Tb/s"
 
-#: src/utils/units.rs:205
+#: src/utils/units.rs:222
 msgid "{} Pb/s"
 msgstr "{} Pb/s"
 
-#: src/utils/units.rs:206
+#: src/utils/units.rs:223
 msgid "{} Eb/s"
 msgstr "{} Eb/s"
 
-#: src/utils/units.rs:207
+#: src/utils/units.rs:224
 msgid "{} Zb/s"
 msgstr "{} Zb/s"
 
-#: src/utils/units.rs:208
+#: src/utils/units.rs:225
 msgid "{} Yb/s"
 msgstr "{} Yb/s"
 
-#: src/utils/units.rs:209
+#: src/utils/units.rs:226
 msgid "{} Rb/s"
 msgstr "{} Rb/s"
 
-#: src/utils/units.rs:210
+#: src/utils/units.rs:227
 msgid "{} Qb/s"
 msgstr "{} Qb/s"
 
-#: src/utils/units.rs:218
+#: src/utils/units.rs:235
 msgid "{} Kib/s"
 msgstr "{} Kib/s"
 
-#: src/utils/units.rs:219
+#: src/utils/units.rs:236
 msgid "{} Mib/s"
 msgstr "{} Mib/s"
 
-#: src/utils/units.rs:220
+#: src/utils/units.rs:237
 msgid "{} Gib/s"
 msgstr "{} Gib/s"
 
-#: src/utils/units.rs:221
+#: src/utils/units.rs:238
 msgid "{} Tib/s"
 msgstr "{} Tib/s"
 
-#: src/utils/units.rs:222
+#: src/utils/units.rs:239
 msgid "{} Pib/s"
 msgstr "{} Pib/s"
 
-#: src/utils/units.rs:223
+#: src/utils/units.rs:240
 msgid "{} Eib/s"
 msgstr "{} Eib/s"
 
-#: src/utils/units.rs:224
+#: src/utils/units.rs:241
 msgid "{} Zib/s"
 msgstr "{} Zib/s"
 
-#: src/utils/units.rs:225
+#: src/utils/units.rs:242
 msgid "{} Yib/s"
 msgstr "{} Yib/s"
 
-#: src/utils/units.rs:226
+#: src/utils/units.rs:243
 msgid "{} Rib/s"
 msgstr "{} Rib/s"
 
-#: src/utils/units.rs:227
+#: src/utils/units.rs:244
 msgid "{} Qib/s"
 msgstr "{} Qib/s"
 
-#: src/utils/units.rs:234
+#: src/utils/units.rs:251
 msgid "{} Hz"
 msgstr "{} Hz"
 
-#: src/utils/units.rs:235
+#: src/utils/units.rs:252
 msgid "{} kHz"
 msgstr "{} kHz"
 
-#: src/utils/units.rs:236
+#: src/utils/units.rs:253
 msgid "{} MHz"
 msgstr "{} MHz"
 
-#: src/utils/units.rs:237
+#: src/utils/units.rs:254
 msgid "{} GHz"
 msgstr "{} GHz"
 
-#: src/utils/units.rs:238
+#: src/utils/units.rs:255
 msgid "{} THz"
 msgstr "{} THz"
 
-#: src/utils/units.rs:239
+#: src/utils/units.rs:256
 msgid "{} PHz"
 msgstr "{} PHz"
 
-#: src/utils/units.rs:240
+#: src/utils/units.rs:257
 msgid "{} EHz"
 msgstr "{} EHz"
 
-#: src/utils/units.rs:241
+#: src/utils/units.rs:258
 msgid "{} ZHz"
 msgstr "{} ZHz"
 
-#: src/utils/units.rs:242
+#: src/utils/units.rs:259
 msgid "{} YHz"
 msgstr "{} YHz"
 
-#: src/utils/units.rs:243
+#: src/utils/units.rs:260
 msgid "{} RHz"
 msgstr "{} RHz"
 
-#: src/utils/units.rs:244
+#: src/utils/units.rs:261
 msgid "{} QHz"
 msgstr "{} QHz"
 
-#: src/utils/units.rs:251
+#: src/utils/units.rs:268
 msgid "{} W"
 msgstr "{} W"
 
-#: src/utils/units.rs:252
+#: src/utils/units.rs:269
 msgid "{} kW"
 msgstr "{} kW"
 
-#: src/utils/units.rs:253
+#: src/utils/units.rs:270
 msgid "{} MW"
 msgstr "{} MW"
 
-#: src/utils/units.rs:254
+#: src/utils/units.rs:271
 msgid "{} GW"
 msgstr "{} GW"
 
-#: src/utils/units.rs:255
+#: src/utils/units.rs:272
 msgid "{} TW"
 msgstr "{} TW"
 
-#: src/utils/units.rs:256
+#: src/utils/units.rs:273
 msgid "{} PW"
 msgstr "{} PW"
 
-#: src/utils/units.rs:257
+#: src/utils/units.rs:274
 msgid "{} EW"
 msgstr "{} EW"
 
-#: src/utils/units.rs:258
+#: src/utils/units.rs:275
 msgid "{} ZW"
 msgstr "{} ZW"
 
-#: src/utils/units.rs:259
+#: src/utils/units.rs:276
 msgid "{} YW"
 msgstr "{} YW"
 
-#: src/utils/units.rs:260
+#: src/utils/units.rs:277
 msgid "{} RW"
 msgstr "{} RW"
 
-#: src/utils/units.rs:261
+#: src/utils/units.rs:278
 msgid "{} QW"
 msgstr "{} QW"
 
-#: src/utils/units.rs:270 src/utils/units.rs:284
+#: src/utils/units.rs:287 src/utils/units.rs:301
 msgid "{} Wh"
 msgstr "{} Wh"
 
-#: src/utils/units.rs:271 src/utils/units.rs:285
+#: src/utils/units.rs:288 src/utils/units.rs:302
 msgid "{} kWh"
 msgstr "{} kWh"
 
-#: src/utils/units.rs:272 src/utils/units.rs:286
+#: src/utils/units.rs:289 src/utils/units.rs:303
 msgid "{} MWh"
 msgstr "{} MWh"
 
-#: src/utils/units.rs:273 src/utils/units.rs:287
+#: src/utils/units.rs:290 src/utils/units.rs:304
 msgid "{} GWh"
 msgstr "{} GWh"
 
-#: src/utils/units.rs:274 src/utils/units.rs:288
+#: src/utils/units.rs:291 src/utils/units.rs:305
 msgid "{} TWh"
 msgstr "{} TWh"
 
-#: src/utils/units.rs:275 src/utils/units.rs:289
+#: src/utils/units.rs:292 src/utils/units.rs:306
 msgid "{} PWh"
 msgstr "{} PWh"
 
-#: src/utils/units.rs:276 src/utils/units.rs:290
+#: src/utils/units.rs:293 src/utils/units.rs:307
 msgid "{} EWh"
 msgstr "{} EWh"
 
-#: src/utils/units.rs:277 src/utils/units.rs:291
+#: src/utils/units.rs:294 src/utils/units.rs:308
 msgid "{} ZWh"
 msgstr "{} ZWh"
 
-#: src/utils/units.rs:278 src/utils/units.rs:292
+#: src/utils/units.rs:295 src/utils/units.rs:309
 msgid "{} YWh"
 msgstr "{} YWh"
 
-#: src/utils/units.rs:279 src/utils/units.rs:293
+#: src/utils/units.rs:296 src/utils/units.rs:310
 msgid "{} RWh"
 msgstr "{} RWh"
 
-#: src/utils/units.rs:280 src/utils/units.rs:294
+#: src/utils/units.rs:297 src/utils/units.rs:311
 msgid "{} QWh"
 msgstr "{} QWh"
 
@@ -1322,6 +1329,14 @@ msgstr "Tastenkombinationen"
 msgid "About Resources"
 msgstr "Über Ressourcen"
 
+#: data/resources/ui/window.ui:88 data/resources/ui/window.ui:128
+msgid "Search"
+msgstr "Suchen"
+
+#: data/resources/ui/window.ui:90 data/resources/ui/window.ui:130
+msgid "Toggle search field"
+msgstr "Suchfeld umschalten"
+
 #: data/resources/ui/dialogs/app_dialog.ui:7
 msgid "App Information"
 msgstr "Anwendungsinformationen"
@@ -1337,10 +1352,10 @@ msgstr "Auslastung"
 
 #: data/resources/ui/dialogs/app_dialog.ui:174
 #: data/resources/ui/dialogs/process_dialog.ui:179
-#: data/resources/ui/pages/battery.ui:33 data/resources/ui/pages/cpu.ui:89
-#: data/resources/ui/pages/drive.ui:54 data/resources/ui/pages/gpu.ui:80
+#: data/resources/ui/pages/battery.ui:33 data/resources/ui/pages/cpu.ui:83
+#: data/resources/ui/pages/drive.ui:54 data/resources/ui/pages/gpu.ui:74
 #: data/resources/ui/pages/memory.ui:42 data/resources/ui/pages/network.ui:51
-#: data/resources/ui/pages/npu.ui:74
+#: data/resources/ui/pages/npu.ui:68
 msgid "Properties"
 msgstr "Eigenschaften"
 
@@ -1519,22 +1534,18 @@ msgid "Graph Data Points"
 msgstr "Datenpunkte in Graphen"
 
 #: data/resources/ui/dialogs/settings_dialog.ui:86
-msgid "Show Search Fields on Launch"
-msgstr "Alle Suchfelder beim Start anzeigen"
-
-#: data/resources/ui/dialogs/settings_dialog.ui:91
 msgid "Show Usage Details in Sidebar"
 msgstr "Auslastungsdetails in der Seitenleiste anzeigen"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:92
+#: data/resources/ui/dialogs/settings_dialog.ui:87
 msgid "If enabled, the usage along with other information will be displayed"
 msgstr "Falls aktiv, werden die Auslastung und andere Informationen angezeigt"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:97
+#: data/resources/ui/dialogs/settings_dialog.ui:92
 msgid "Show Device Descriptions in Sidebar"
 msgstr "Gerätebeschreibungen in der Seitenleiste anzeigen"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:98
+#: data/resources/ui/dialogs/settings_dialog.ui:93
 msgid ""
 "If enabled, a device identifier like its name or device type will be "
 "displayed"
@@ -1542,23 +1553,23 @@ msgstr ""
 "Falls aktiv, wird ein Bezeichner wie der Name oder Gerätetyp des Geräts "
 "angezeigt"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:103
+#: data/resources/ui/dialogs/settings_dialog.ui:98
 msgid "Sidebar Meter Type"
 msgstr "Auslastungsdarstellung in der Seitenleiste"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:107
+#: data/resources/ui/dialogs/settings_dialog.ui:102
 msgid "Bar"
 msgstr "Leiste"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:108
+#: data/resources/ui/dialogs/settings_dialog.ui:103
 msgid "Graph"
 msgstr "Graph"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:116
+#: data/resources/ui/dialogs/settings_dialog.ui:111
 msgid "Normalize Processor Usage"
 msgstr "Prozessorauslastung normalisieren"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:117
+#: data/resources/ui/dialogs/settings_dialog.ui:112
 msgid ""
 "If enabled, the total usage of all cores will be divided by the amount of "
 "cores"
@@ -1566,46 +1577,46 @@ msgstr ""
 "Falls aktiv, wird die summierte Auslastung aller Kerne durch die Anzahl "
 "dividiert"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:130
-#: data/resources/ui/dialogs/settings_dialog.ui:207
+#: data/resources/ui/dialogs/settings_dialog.ui:125
+#: data/resources/ui/dialogs/settings_dialog.ui:202
 msgid "Information Columns"
 msgstr "Informationsspalten"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:196
+#: data/resources/ui/dialogs/settings_dialog.ui:191
 #: data/resources/ui/pages/cpu.ui:22 data/resources/ui/pages/processes.ui:56
 msgid "Options"
 msgstr "Optionen"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:199
+#: data/resources/ui/dialogs/settings_dialog.ui:194
 msgid "Show Niceness Values"
 msgstr "Nice-Werte anzeigen"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:200
+#: data/resources/ui/dialogs/settings_dialog.ui:195
 msgid ""
 "Display priorities as niceness to allow for more fine-grained adjustments"
 msgstr "Prioritäten als Nice-Wert um feinere Anpassungen zu ermöglichen"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:300
+#: data/resources/ui/dialogs/settings_dialog.ui:295
 msgid "Devices"
 msgstr "Geräte"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:303
+#: data/resources/ui/dialogs/settings_dialog.ui:298
 msgid "Drives"
 msgstr "Datenträger"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:306
+#: data/resources/ui/dialogs/settings_dialog.ui:301
 msgid "Show Virtual Drives"
 msgstr "Virtuelle Laufwerke anzeigen"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:307
+#: data/resources/ui/dialogs/settings_dialog.ui:302
 msgid "Virtual drives are for example ZFS volumes or mapped devices"
 msgstr "Als virtuelle Laufwerke zählen zum Beispiel ZFS-Volumen oder RAM-Disks"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:317
+#: data/resources/ui/dialogs/settings_dialog.ui:312
 msgid "Show Virtual Network Interfaces"
 msgstr "Virtuelle Netzwerkschnittstellen anzeigen"
 
-#: data/resources/ui/dialogs/settings_dialog.ui:318
+#: data/resources/ui/dialogs/settings_dialog.ui:313
 msgid "Virtual network interfaces are for example bridges or VPN tunnels"
 msgstr ""
 "Als virtuelle Netzwerkschnittstellen zählen zum Beispiel Bridges oder Tunnel"
@@ -1615,22 +1626,12 @@ msgstr ""
 msgid "Information"
 msgstr "Informationen"
 
-#: data/resources/ui/pages/applications.ui:80
+#: data/resources/ui/pages/applications.ui:57
 msgid "Search applications"
 msgstr "Anwendungen suchen"
 
-#: data/resources/ui/pages/applications.ui:98
-#: data/resources/ui/pages/processes.ui:144
-msgid "Search"
-msgstr "Suchen"
-
-#: data/resources/ui/pages/applications.ui:100
-#: data/resources/ui/pages/processes.ui:146
-msgid "Toggle search field"
-msgstr "Suchfeld umschalten"
-
-#: data/resources/ui/pages/applications.ui:116
-#: data/resources/ui/pages/applications.ui:118
+#: data/resources/ui/pages/applications.ui:87
+#: data/resources/ui/pages/applications.ui:89
 msgid "Show App Information"
 msgstr "Anwendungsinformationen anzeigen"
 
@@ -1650,8 +1651,8 @@ msgstr "Ladezyklen"
 msgid "Technology"
 msgstr "Technologie"
 
-#: data/resources/ui/pages/battery.ui:72 data/resources/ui/pages/gpu.ui:87
-#: data/resources/ui/pages/network.ui:58 data/resources/ui/pages/npu.ui:81
+#: data/resources/ui/pages/battery.ui:72 data/resources/ui/pages/gpu.ui:81
+#: data/resources/ui/pages/network.ui:58 data/resources/ui/pages/npu.ui:75
 msgid "Manufacturer"
 msgstr "Hersteller"
 
@@ -1672,32 +1673,27 @@ msgstr "Auslastung der logischen Prozessoren anzeigen"
 msgid "Sensors"
 msgstr "Sensoren"
 
-#: data/resources/ui/pages/cpu.ui:82 data/resources/ui/pages/gpu.ui:69
-#: data/resources/ui/pages/npu.ui:63
-msgid "Temperature"
-msgstr "Temperatur"
-
-#: data/resources/ui/pages/cpu.ui:96
+#: data/resources/ui/pages/cpu.ui:90
 msgid "Max Frequency"
 msgstr "Maximale Taktfrequenz"
 
-#: data/resources/ui/pages/cpu.ui:105
+#: data/resources/ui/pages/cpu.ui:99
 msgid "Logical Cores"
 msgstr "Logische Kerne"
 
-#: data/resources/ui/pages/cpu.ui:114
+#: data/resources/ui/pages/cpu.ui:108
 msgid "Physical Cores"
 msgstr "Physische Kerne"
 
-#: data/resources/ui/pages/cpu.ui:123
+#: data/resources/ui/pages/cpu.ui:117
 msgid "Sockets"
 msgstr "Sockel"
 
-#: data/resources/ui/pages/cpu.ui:132
+#: data/resources/ui/pages/cpu.ui:126
 msgid "Virtualization"
 msgstr "Virtualisierung"
 
-#: data/resources/ui/pages/cpu.ui:141
+#: data/resources/ui/pages/cpu.ui:135
 msgid "Architecture"
 msgstr "Architektur"
 
@@ -1725,6 +1721,10 @@ msgstr "Beschreibbar"
 msgid "Removable"
 msgstr "Wechselspeicher"
 
+#: data/resources/ui/pages/drive.ui:102 data/resources/ui/pages/gpu.ui:113
+msgid "Link"
+msgstr "Anbindung"
+
 #: data/resources/ui/pages/gpu.ui:37
 msgid "GPU Frequency"
 msgstr "GPU-Frequenz"
@@ -1733,16 +1733,16 @@ msgstr "GPU-Frequenz"
 msgid "Video Memory Frequency"
 msgstr "Grafikspeichertaktfrequenz"
 
-#: data/resources/ui/pages/gpu.ui:96 data/resources/ui/pages/npu.ui:90
+#: data/resources/ui/pages/gpu.ui:90 data/resources/ui/pages/npu.ui:84
 msgid "PCI Slot"
 msgstr "PCI-Slot"
 
-#: data/resources/ui/pages/gpu.ui:105 data/resources/ui/pages/network.ui:67
-#: data/resources/ui/pages/npu.ui:99
+#: data/resources/ui/pages/gpu.ui:99 data/resources/ui/pages/network.ui:67
+#: data/resources/ui/pages/npu.ui:93
 msgid "Driver Used"
 msgstr "Benutzter Treiber"
 
-#: data/resources/ui/pages/gpu.ui:114 data/resources/ui/pages/npu.ui:108
+#: data/resources/ui/pages/gpu.ui:108 data/resources/ui/pages/npu.ui:102
 msgid "Max Power Cap"
 msgstr "Maximale Leistungsbegrenzung"
 
@@ -1809,19 +1809,22 @@ msgstr "Prozesse anhalten"
 msgid "Continue Processes"
 msgstr "Prozesse fortsetzen"
 
-#: data/resources/ui/pages/processes.ui:126
+#: data/resources/ui/pages/processes.ui:103
 msgid "Search processes"
 msgstr "Prozesse suchen"
 
-#: data/resources/ui/pages/processes.ui:162
-#: data/resources/ui/pages/processes.ui:164
+#: data/resources/ui/pages/processes.ui:133
+#: data/resources/ui/pages/processes.ui:135
 msgid "Show Process Options"
 msgstr "Prozessoptionen anzeigen"
 
-#: data/resources/ui/pages/processes.ui:175
-#: data/resources/ui/pages/processes.ui:177
+#: data/resources/ui/pages/processes.ui:146
+#: data/resources/ui/pages/processes.ui:148
 msgid "Show Process Information"
 msgstr "Prozessinformationen anzeigen"
+
+#~ msgid "Show Search Fields on Launch"
+#~ msgstr "Alle Suchfelder beim Start anzeigen"
 
 #~ msgid "VRAM: {}"
 #~ msgstr "VRAM: {}"

--- a/po/resources.pot
+++ b/po/resources.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-19 13:51+0200\n"
+"POT-Creation-Date: 2025-02-16 19:23+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
 #: data/net.nokyan.Resources.desktop.in.in:3
-#: data/net.nokyan.Resources.metainfo.xml.in.in:4 src/application.rs:262
+#: data/net.nokyan.Resources.metainfo.xml.in.in:4 src/application.rs:265
 #: data/resources/ui/window.ui:22
 msgid "Resources"
 msgstr ""
@@ -51,28 +51,28 @@ msgid "CPU"
 msgstr ""
 
 #: data/net.nokyan.Resources.metainfo.xml.in.in:25
-#: src/ui/pages/applications/mod.rs:811 src/ui/pages/memory.rs:105
-#: src/ui/pages/memory.rs:186 src/ui/pages/processes/mod.rs:1087
-#: data/resources/ui/window.ui:158 data/resources/ui/window.ui:165
+#: src/ui/pages/applications/mod.rs:801 src/ui/pages/memory.rs:106
+#: src/ui/pages/memory.rs:191 src/ui/pages/processes/mod.rs:1077
+#: data/resources/ui/window.ui:176 data/resources/ui/window.ui:183
 #: data/resources/ui/dialogs/app_dialog.ui:82
 #: data/resources/ui/dialogs/process_dialog.ui:64
-#: data/resources/ui/dialogs/settings_dialog.ui:133
-#: data/resources/ui/dialogs/settings_dialog.ui:220
+#: data/resources/ui/dialogs/settings_dialog.ui:128
+#: data/resources/ui/dialogs/settings_dialog.ui:215
 msgid "Memory"
 msgstr ""
 
 #: data/net.nokyan.Resources.metainfo.xml.in.in:26
-#: src/ui/pages/applications/mod.rs:1184 src/ui/pages/gpu.rs:114
-#: src/ui/pages/processes/mod.rs:1471 src/ui/window.rs:311
+#: src/ui/pages/applications/mod.rs:1174 src/ui/pages/gpu.rs:118
+#: src/ui/pages/processes/mod.rs:1461 src/ui/window.rs:460
 #: data/resources/ui/dialogs/app_dialog.ui:140
 #: data/resources/ui/dialogs/process_dialog.ui:118
-#: data/resources/ui/dialogs/settings_dialog.ui:163
-#: data/resources/ui/dialogs/settings_dialog.ui:250
+#: data/resources/ui/dialogs/settings_dialog.ui:158
+#: data/resources/ui/dialogs/settings_dialog.ui:245
 msgid "GPU"
 msgstr ""
 
 #: data/net.nokyan.Resources.metainfo.xml.in.in:27
-#: data/resources/ui/dialogs/settings_dialog.ui:314
+#: data/resources/ui/dialogs/settings_dialog.ui:309
 msgid "Network Interfaces"
 msgstr ""
 
@@ -116,540 +116,547 @@ msgstr ""
 msgid "Battery page in dark theme"
 msgstr ""
 
-#: src/application.rs:264
+#: src/application.rs:267
 msgid "The Nalux Team"
 msgstr ""
 
-#: src/application.rs:272
+#: src/application.rs:275
 msgid "Report Issues"
 msgstr ""
 
 #. Translator credits. Replace "translator-credits" with your name/username, and optionally an email or URL.
 #. One name per line, please do not remove previous names.
-#: src/application.rs:278
+#: src/application.rs:281
 msgid "translator-credits"
 msgstr ""
 
-#: src/application.rs:279
+#: src/application.rs:282
 msgid "Icon by"
 msgstr ""
 
-#: src/ui/dialogs/app_dialog.rs:148 src/ui/dialogs/process_dialog.rs:127
-#: src/ui/dialogs/process_dialog.rs:131 src/ui/dialogs/process_dialog.rs:140
-#: src/ui/dialogs/process_dialog.rs:142 src/ui/dialogs/process_dialog.rs:163
-#: src/ui/dialogs/process_dialog.rs:170 src/ui/dialogs/process_dialog.rs:177
-#: src/ui/dialogs/process_dialog.rs:184 src/ui/pages/applications/mod.rs:954
-#: src/ui/pages/applications/mod.rs:1078 src/ui/pages/battery.rs:196
-#: src/ui/pages/battery.rs:216 src/ui/pages/battery.rs:222
-#: src/ui/pages/battery.rs:225 src/ui/pages/battery.rs:251
-#: src/ui/pages/battery.rs:275 src/ui/pages/battery.rs:277
-#: src/ui/pages/battery.rs:287 src/ui/pages/cpu.rs:218 src/ui/pages/cpu.rs:233
-#: src/ui/pages/cpu.rs:248 src/ui/pages/cpu.rs:254 src/ui/pages/cpu.rs:260
-#: src/ui/pages/cpu.rs:266 src/ui/pages/cpu.rs:270 src/ui/pages/cpu.rs:273
-#: src/ui/pages/cpu.rs:370 src/ui/pages/drive.rs:298 src/ui/pages/drive.rs:329
-#: src/ui/pages/drive.rs:331 src/ui/pages/drive.rs:360
-#: src/ui/pages/drive.rs:362 src/ui/pages/drive.rs:378
-#: src/ui/pages/drive.rs:379 src/ui/pages/drive.rs:386
-#: src/ui/pages/drive.rs:396 src/ui/pages/drive.rs:406 src/ui/pages/gpu.rs:227
-#: src/ui/pages/gpu.rs:267 src/ui/pages/gpu.rs:292 src/ui/pages/gpu.rs:295
-#: src/ui/pages/gpu.rs:306 src/ui/pages/gpu.rs:326 src/ui/pages/gpu.rs:338
-#: src/ui/pages/gpu.rs:352 src/ui/pages/gpu.rs:354 src/ui/pages/gpu.rs:366
-#: src/ui/pages/gpu.rs:373 src/ui/pages/gpu.rs:377 src/ui/pages/memory.rs:221
-#: src/ui/pages/memory.rs:222 src/ui/pages/memory.rs:226
-#: src/ui/pages/memory.rs:227 src/ui/pages/memory.rs:231
-#: src/ui/pages/memory.rs:232 src/ui/pages/memory.rs:260
-#: src/ui/pages/memory.rs:317 src/ui/pages/network.rs:230
+#: src/ui/dialogs/app_dialog.rs:153 src/ui/dialogs/process_dialog.rs:131
+#: src/ui/dialogs/process_dialog.rs:135 src/ui/dialogs/process_dialog.rs:144
+#: src/ui/dialogs/process_dialog.rs:146 src/ui/dialogs/process_dialog.rs:169
+#: src/ui/dialogs/process_dialog.rs:176 src/ui/dialogs/process_dialog.rs:183
+#: src/ui/dialogs/process_dialog.rs:190 src/ui/pages/applications/mod.rs:944
+#: src/ui/pages/applications/mod.rs:1068 src/ui/pages/battery.rs:204
+#: src/ui/pages/battery.rs:224 src/ui/pages/battery.rs:230
+#: src/ui/pages/battery.rs:233 src/ui/pages/battery.rs:264
+#: src/ui/pages/battery.rs:288 src/ui/pages/battery.rs:290
+#: src/ui/pages/battery.rs:300 src/ui/pages/cpu.rs:238 src/ui/pages/cpu.rs:253
+#: src/ui/pages/cpu.rs:272 src/ui/pages/cpu.rs:278 src/ui/pages/cpu.rs:284
+#: src/ui/pages/cpu.rs:290 src/ui/pages/cpu.rs:294 src/ui/pages/cpu.rs:297
+#: src/ui/pages/cpu.rs:420 src/ui/pages/drive.rs:315 src/ui/pages/drive.rs:346
+#: src/ui/pages/drive.rs:348 src/ui/pages/drive.rs:377
+#: src/ui/pages/drive.rs:379 src/ui/pages/drive.rs:395
+#: src/ui/pages/drive.rs:396 src/ui/pages/drive.rs:403
+#: src/ui/pages/drive.rs:413 src/ui/pages/drive.rs:423
+#: src/ui/pages/drive.rs:429 src/ui/pages/gpu.rs:243 src/ui/pages/gpu.rs:250
+#: src/ui/pages/gpu.rs:295 src/ui/pages/gpu.rs:320 src/ui/pages/gpu.rs:323
+#: src/ui/pages/gpu.rs:334 src/ui/pages/gpu.rs:354 src/ui/pages/gpu.rs:366
+#: src/ui/pages/gpu.rs:377 src/ui/pages/gpu.rs:389 src/ui/pages/gpu.rs:396
+#: src/ui/pages/gpu.rs:400 src/ui/pages/gpu.rs:430 src/ui/pages/gpu.rs:436
+#: src/ui/pages/memory.rs:226 src/ui/pages/memory.rs:227
+#: src/ui/pages/memory.rs:231 src/ui/pages/memory.rs:232
+#: src/ui/pages/memory.rs:236 src/ui/pages/memory.rs:237
+#: src/ui/pages/memory.rs:265 src/ui/pages/memory.rs:326
 #: src/ui/pages/network.rs:237 src/ui/pages/network.rs:244
-#: src/ui/pages/network.rs:250 src/ui/pages/network.rs:253
-#: src/ui/pages/network.rs:314 src/ui/pages/network.rs:317
-#: src/ui/pages/network.rs:319 src/ui/pages/network.rs:348
-#: src/ui/pages/network.rs:351 src/ui/pages/network.rs:353
-#: src/ui/pages/npu.rs:201 src/ui/pages/npu.rs:230 src/ui/pages/npu.rs:248
-#: src/ui/pages/npu.rs:260 src/ui/pages/npu.rs:274 src/ui/pages/npu.rs:276
-#: src/ui/pages/npu.rs:288 src/ui/pages/npu.rs:295 src/ui/pages/npu.rs:299
-#: src/ui/pages/processes/mod.rs:1229 src/ui/pages/processes/mod.rs:1295
-#: src/ui/pages/processes/mod.rs:1361 src/ui/pages/processes/mod.rs:1427
-#: src/ui/pages/processes/mod.rs:1909 src/ui/pages/processes/mod.rs:1911
-#: src/utils/battery.rs:136 src/utils/drive.rs:89 src/utils/gpu/mod.rs:274
-#: src/utils/gpu/mod.rs:280 src/utils/npu/mod.rs:241 src/utils/npu/mod.rs:247
+#: src/ui/pages/network.rs:251 src/ui/pages/network.rs:257
+#: src/ui/pages/network.rs:260 src/ui/pages/network.rs:326
+#: src/ui/pages/network.rs:329 src/ui/pages/network.rs:331
+#: src/ui/pages/network.rs:360 src/ui/pages/network.rs:363
+#: src/ui/pages/network.rs:365 src/ui/pages/npu.rs:214 src/ui/pages/npu.rs:249
+#: src/ui/pages/npu.rs:304 src/ui/pages/npu.rs:313 src/ui/pages/npu.rs:325
+#: src/ui/pages/npu.rs:332 src/ui/pages/npu.rs:336 src/ui/pages/npu.rs:357
+#: src/ui/pages/processes/mod.rs:1219 src/ui/pages/processes/mod.rs:1285
+#: src/ui/pages/processes/mod.rs:1351 src/ui/pages/processes/mod.rs:1417
+#: src/ui/pages/processes/mod.rs:1899 src/ui/pages/processes/mod.rs:1901
+#: src/utils/battery.rs:149 src/utils/drive.rs:108 src/utils/gpu/mod.rs:284
+#: src/utils/gpu/mod.rs:296 src/utils/link.rs:99 src/utils/link.rs:150
+#: src/utils/npu/mod.rs:252 src/utils/npu/mod.rs:258
 msgid "N/A"
 msgstr ""
 
-#: src/ui/dialogs/process_options_dialog.rs:141 src/ui/pages/cpu.rs:232
-#: src/ui/pages/cpu.rs:354 src/ui/pages/cpu.rs:358
+#: src/ui/dialogs/process_options_dialog.rs:145 src/ui/pages/cpu.rs:252
+#: src/ui/pages/cpu.rs:391 src/ui/pages/cpu.rs:395
 msgid "CPU {}"
 msgstr ""
 
-#: src/ui/pages/applications/application_entry.rs:183 src/ui/pages/drive.rs:393
-#: src/ui/pages/drive.rs:403 src/ui/pages/processes/process_entry.rs:204
+#: src/ui/pages/applications/application_entry.rs:186 src/ui/pages/drive.rs:410
+#: src/ui/pages/drive.rs:420 src/ui/pages/processes/process_entry.rs:207
 msgid "No"
 msgstr ""
 
-#: src/ui/pages/applications/application_entry.rs:184
-#: src/ui/pages/processes/process_entry.rs:205
+#: src/ui/pages/applications/application_entry.rs:187
+#: src/ui/pages/processes/process_entry.rs:208
 msgid "Yes (Flatpak)"
 msgstr ""
 
-#: src/ui/pages/applications/application_entry.rs:185
-#: src/ui/pages/processes/process_entry.rs:206
+#: src/ui/pages/applications/application_entry.rs:188
+#: src/ui/pages/processes/process_entry.rs:209
 msgid "Yes (Snap)"
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:134 data/resources/ui/window.ui:65
+#: src/ui/pages/applications/mod.rs:131 data/resources/ui/window.ui:65
 #: data/resources/ui/window.ui:72
-#: data/resources/ui/dialogs/settings_dialog.ui:127
+#: data/resources/ui/dialogs/settings_dialog.ui:122
 msgid "Apps"
 msgstr ""
 
 #. -1 because we don't want to count System Processes
-#: src/ui/pages/applications/mod.rs:668
+#: src/ui/pages/applications/mod.rs:658
 msgid "Running Apps: {}"
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:708 src/ui/pages/processes/mod.rs:870
+#: src/ui/pages/applications/mod.rs:698 src/ui/pages/processes/mod.rs:860
 msgid "Cancel"
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:754
+#: src/ui/pages/applications/mod.rs:744
 msgid "App"
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:870 src/ui/pages/cpu.rs:122
-#: src/ui/pages/processes/mod.rs:1145 src/ui/window.rs:403
-#: data/resources/ui/window.ui:127 data/resources/ui/window.ui:134
+#: src/ui/pages/applications/mod.rs:860 src/ui/pages/cpu.rs:123
+#: src/ui/pages/processes/mod.rs:1135 src/ui/window.rs:289
+#: data/resources/ui/window.ui:145 data/resources/ui/window.ui:152
 #: data/resources/ui/dialogs/app_dialog.ui:73
 #: data/resources/ui/dialogs/process_dialog.ui:55
-#: data/resources/ui/dialogs/settings_dialog.ui:138
-#: data/resources/ui/dialogs/settings_dialog.ui:225
+#: data/resources/ui/dialogs/settings_dialog.ui:133
+#: data/resources/ui/dialogs/settings_dialog.ui:220
 msgid "Processor"
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:933 src/ui/pages/processes/mod.rs:1208
+#: src/ui/pages/applications/mod.rs:923 src/ui/pages/processes/mod.rs:1198
 #: data/resources/ui/dialogs/app_dialog.ui:100
 #: data/resources/ui/dialogs/process_dialog.ui:78
-#: data/resources/ui/dialogs/settings_dialog.ui:143
-#: data/resources/ui/dialogs/settings_dialog.ui:230
+#: data/resources/ui/dialogs/settings_dialog.ui:138
+#: data/resources/ui/dialogs/settings_dialog.ui:225
 msgid "Drive Read"
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:997 src/ui/pages/processes/mod.rs:1274
+#: src/ui/pages/applications/mod.rs:987 src/ui/pages/processes/mod.rs:1264
 #: data/resources/ui/dialogs/app_dialog.ui:109
 #: data/resources/ui/dialogs/process_dialog.ui:87
-#: data/resources/ui/dialogs/settings_dialog.ui:148
-#: data/resources/ui/dialogs/settings_dialog.ui:235
+#: data/resources/ui/dialogs/settings_dialog.ui:143
+#: data/resources/ui/dialogs/settings_dialog.ui:230
 msgid "Drive Read Total"
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:1057 src/ui/pages/processes/mod.rs:1340
+#: src/ui/pages/applications/mod.rs:1047 src/ui/pages/processes/mod.rs:1330
 #: data/resources/ui/dialogs/app_dialog.ui:118
 #: data/resources/ui/dialogs/process_dialog.ui:96
-#: data/resources/ui/dialogs/settings_dialog.ui:153
-#: data/resources/ui/dialogs/settings_dialog.ui:240
+#: data/resources/ui/dialogs/settings_dialog.ui:148
+#: data/resources/ui/dialogs/settings_dialog.ui:235
 msgid "Drive Write"
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:1123 src/ui/pages/processes/mod.rs:1406
+#: src/ui/pages/applications/mod.rs:1113 src/ui/pages/processes/mod.rs:1396
 #: data/resources/ui/dialogs/app_dialog.ui:127
 #: data/resources/ui/dialogs/process_dialog.ui:105
-#: data/resources/ui/dialogs/settings_dialog.ui:158
-#: data/resources/ui/dialogs/settings_dialog.ui:245
+#: data/resources/ui/dialogs/settings_dialog.ui:153
+#: data/resources/ui/dialogs/settings_dialog.ui:240
 msgid "Drive Write Total"
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:1242 src/ui/pages/processes/mod.rs:1529
+#: src/ui/pages/applications/mod.rs:1232 src/ui/pages/processes/mod.rs:1519
 #: data/resources/ui/dialogs/app_dialog.ui:158
 #: data/resources/ui/dialogs/process_dialog.ui:136
-#: data/resources/ui/dialogs/settings_dialog.ui:173
-#: data/resources/ui/dialogs/settings_dialog.ui:260
+#: data/resources/ui/dialogs/settings_dialog.ui:168
+#: data/resources/ui/dialogs/settings_dialog.ui:255
 msgid "Video Encoder"
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:1302 src/ui/pages/processes/mod.rs:1589
+#: src/ui/pages/applications/mod.rs:1292 src/ui/pages/processes/mod.rs:1579
 #: data/resources/ui/dialogs/app_dialog.ui:167
 #: data/resources/ui/dialogs/process_dialog.ui:145
-#: data/resources/ui/dialogs/settings_dialog.ui:178
-#: data/resources/ui/dialogs/settings_dialog.ui:265
+#: data/resources/ui/dialogs/settings_dialog.ui:173
+#: data/resources/ui/dialogs/settings_dialog.ui:260
 msgid "Video Decoder"
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:1361 src/ui/pages/processes/mod.rs:1649
+#: src/ui/pages/applications/mod.rs:1351 src/ui/pages/processes/mod.rs:1639
 #: data/resources/ui/dialogs/app_dialog.ui:149
 #: data/resources/ui/dialogs/process_dialog.ui:127
-#: data/resources/ui/dialogs/settings_dialog.ui:168
-#: data/resources/ui/dialogs/settings_dialog.ui:255
+#: data/resources/ui/dialogs/settings_dialog.ui:163
+#: data/resources/ui/dialogs/settings_dialog.ui:250
 msgid "Video Memory"
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:1419 src/ui/pages/memory.rs:192
-#: src/ui/pages/processes/mod.rs:1952
+#: src/ui/pages/applications/mod.rs:1409 src/ui/pages/memory.rs:197
+#: src/ui/pages/processes/mod.rs:1942
 #: data/resources/ui/dialogs/app_dialog.ui:91
 #: data/resources/ui/dialogs/process_dialog.ui:73
-#: data/resources/ui/dialogs/settings_dialog.ui:183
-#: data/resources/ui/dialogs/settings_dialog.ui:290
+#: data/resources/ui/dialogs/settings_dialog.ui:178
+#: data/resources/ui/dialogs/settings_dialog.ui:285
 msgid "Swap"
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:1477 src/ui/pages/processes/mod.rs:2009
+#: src/ui/pages/applications/mod.rs:1467 src/ui/pages/processes/mod.rs:1999
 msgid "End {}?"
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:1478 src/ui/pages/processes/mod.rs:2010
+#: src/ui/pages/applications/mod.rs:1468 src/ui/pages/processes/mod.rs:2000
 msgid "Halt {}?"
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:1479 src/ui/pages/processes/mod.rs:2011
+#: src/ui/pages/applications/mod.rs:1469 src/ui/pages/processes/mod.rs:2001
 msgid "Kill {}?"
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:1480 src/ui/pages/processes/mod.rs:2012
+#: src/ui/pages/applications/mod.rs:1470 src/ui/pages/processes/mod.rs:2002
 msgid "Continue {}?"
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:1486 src/ui/pages/processes/mod.rs:2047
+#: src/ui/pages/applications/mod.rs:1476 src/ui/pages/processes/mod.rs:2037
 msgid "Unsaved work might be lost."
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:1487
+#: src/ui/pages/applications/mod.rs:1477
 msgid ""
 "Halting an app can come with serious risks such as losing data and security "
 "implications. Use with caution."
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:1488
+#: src/ui/pages/applications/mod.rs:1478
 msgid ""
 "Killing an app can come with serious risks such as losing data and security "
 "implications. Use with caution."
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:1495
+#: src/ui/pages/applications/mod.rs:1485
 #: data/resources/ui/pages/applications.ui:22
-#: data/resources/ui/pages/applications.ui:127
+#: data/resources/ui/pages/applications.ui:98
 msgid "End App"
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:1496
+#: src/ui/pages/applications/mod.rs:1486
 #: data/resources/ui/pages/applications.ui:10
 #: data/resources/ui/pages/applications.ui:30
 msgid "Halt App"
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:1497
+#: src/ui/pages/applications/mod.rs:1487
 #: data/resources/ui/pages/applications.ui:6
 #: data/resources/ui/pages/applications.ui:26
 msgid "Kill App"
 msgstr ""
 
-#: src/ui/pages/applications/mod.rs:1498
+#: src/ui/pages/applications/mod.rs:1488
 #: data/resources/ui/pages/applications.ui:14
 #: data/resources/ui/pages/applications.ui:34
 msgid "Continue App"
 msgstr ""
 
-#: src/ui/pages/battery.rs:101 src/ui/pages/drive.rs:122
+#: src/ui/pages/battery.rs:102 src/ui/pages/drive.rs:126
 msgid "Drive"
 msgstr ""
 
-#: src/ui/pages/battery.rs:201
+#: src/ui/pages/battery.rs:209
 msgid "Battery Charge"
 msgstr ""
 
-#: src/ui/pages/battery.rs:208 data/resources/ui/pages/gpu.ui:55
+#: src/ui/pages/battery.rs:216 data/resources/ui/pages/gpu.ui:55
 #: data/resources/ui/pages/npu.ui:49
 msgid "Power Usage"
 msgstr ""
 
-#: src/ui/pages/battery.rs:265 src/ui/pages/drive.rs:323
-#: src/ui/pages/drive.rs:354 src/ui/pages/network.rs:306
-#: src/ui/pages/network.rs:340
+#: src/ui/pages/battery.rs:278 src/ui/pages/cpu.rs:412
+#: src/ui/pages/drive.rs:340 src/ui/pages/drive.rs:371 src/ui/pages/gpu.rs:422
+#: src/ui/pages/network.rs:318 src/ui/pages/network.rs:352
+#: src/ui/pages/npu.rs:300 src/ui/pages/npu.rs:349
 msgid "Highest:"
 msgstr ""
 
-#: src/ui/pages/cpu.rs:217 src/ui/pages/gpu.rs:198 src/ui/pages/npu.rs:189
+#: src/ui/pages/cpu.rs:237 src/ui/pages/gpu.rs:210 src/ui/pages/npu.rs:198
 msgid "Total Usage"
 msgstr ""
 
-#: src/ui/pages/drive.rs:224
-msgid "Drive Activity"
-msgstr ""
-
-#: src/ui/pages/drive.rs:231
-msgid "Read Speed"
+#: src/ui/pages/cpu.rs:265 src/ui/pages/gpu.rs:237 src/ui/pages/npu.rs:208
+msgid "Temperature"
 msgstr ""
 
 #: src/ui/pages/drive.rs:235
+msgid "Drive Activity"
+msgstr ""
+
+#: src/ui/pages/drive.rs:242
+msgid "Read Speed"
+msgstr ""
+
+#: src/ui/pages/drive.rs:246
 msgid "Write Speed"
 msgstr ""
 
-#: src/ui/pages/drive.rs:391 src/ui/pages/drive.rs:401
+#: src/ui/pages/drive.rs:408 src/ui/pages/drive.rs:418
 msgid "Yes"
 msgstr ""
 
 #. Translators: This is an abbreviation for "Read" and "Write". This is displayed in the sidebar so your
 #. translation should preferably be quite short or an abbreviation
-#: src/ui/pages/drive.rs:413
+#: src/ui/pages/drive.rs:436
 msgid "R: {} · W: {}"
 msgstr ""
 
-#: src/ui/pages/gpu.rs:206
+#: src/ui/pages/gpu.rs:218
 msgid "Video Encoder/Decoder Usage"
 msgstr ""
 
-#: src/ui/pages/gpu.rs:212
+#: src/ui/pages/gpu.rs:224
 msgid "Video Encoder Usage"
 msgstr ""
 
-#: src/ui/pages/gpu.rs:217
+#: src/ui/pages/gpu.rs:229
 msgid "Video Decoder Usage"
 msgstr ""
 
-#: src/ui/pages/gpu.rs:222
+#: src/ui/pages/gpu.rs:234
 msgid "Video Memory Usage"
 msgstr ""
 
 #. Translators: This will be displayed in the sidebar, please try to keep your translation as short as (or even
 #. shorter than) 'Memory'
-#: src/ui/pages/gpu.rs:385 src/ui/pages/npu.rs:307
+#: src/ui/pages/gpu.rs:408 src/ui/pages/npu.rs:274 src/ui/pages/npu.rs:295
 msgid "Memory: {}"
 msgstr ""
 
-#: src/ui/pages/memory.rs:256
+#: src/ui/pages/memory.rs:261
 msgid "{} of {}"
 msgstr ""
 
-#: src/ui/pages/memory.rs:259
+#: src/ui/pages/memory.rs:264
 msgid "{} MT/s"
 msgstr ""
 
 #. Translators: This will be displayed in the sidebar, so your translation for "Swap" should
 #. preferably be quite short or an abbreviation
-#: src/ui/pages/memory.rs:336
+#: src/ui/pages/memory.rs:345
 msgid "{} / {} · Swap: {} %"
 msgstr ""
 
-#: src/ui/pages/network.rs:114 src/utils/network.rs:128
+#: src/ui/pages/network.rs:115 src/utils/network.rs:136
 msgid "Network Interface"
 msgstr ""
 
-#: src/ui/pages/network.rs:218
+#: src/ui/pages/network.rs:226
 msgid "Receiving"
 msgstr ""
 
-#: src/ui/pages/network.rs:222
+#: src/ui/pages/network.rs:230
 msgid "Sending"
 msgstr ""
 
 #. Translators: This is an abbreviation for "Receive" and "Send". This is displayed in the sidebar so
 #. your translation should preferably be quite short or an abbreviation
-#: src/ui/pages/network.rs:363
+#: src/ui/pages/network.rs:375
 msgid "R: {} · S: {}"
 msgstr ""
 
-#: src/ui/pages/npu.rs:105 src/ui/window.rs:343
+#: src/ui/pages/npu.rs:106 src/ui/window.rs:490
 msgid "NPU"
 msgstr ""
 
-#: src/ui/pages/npu.rs:196
+#: src/ui/pages/npu.rs:205
 msgid "Memory Usage"
 msgstr ""
 
-#: src/ui/pages/processes/mod.rs:178 data/resources/ui/window.ui:96
-#: data/resources/ui/window.ui:103
-#: data/resources/ui/dialogs/settings_dialog.ui:193
+#: src/ui/pages/processes/mod.rs:175 data/resources/ui/window.ui:105
+#: data/resources/ui/window.ui:112
+#: data/resources/ui/dialogs/settings_dialog.ui:188
 msgid "Processes"
 msgstr ""
 
-#: src/ui/pages/processes/mod.rs:523 src/ui/pages/processes/mod.rs:2056
+#: src/ui/pages/processes/mod.rs:521 src/ui/pages/processes/mod.rs:2046
 #: data/resources/ui/pages/processes.ui:38
-#: data/resources/ui/pages/processes.ui:186
+#: data/resources/ui/pages/processes.ui:157
 msgid "End Process"
 msgstr ""
 
-#: src/ui/pages/processes/mod.rs:527 data/resources/ui/pages/processes.ui:70
+#: src/ui/pages/processes/mod.rs:525 data/resources/ui/pages/processes.ui:70
 msgid "End Processes"
 msgstr ""
 
-#: src/ui/pages/processes/mod.rs:821
+#: src/ui/pages/processes/mod.rs:811
 msgid "Running Processes: {}"
 msgstr ""
 
-#: src/ui/pages/processes/mod.rs:919
+#: src/ui/pages/processes/mod.rs:909
 msgid "Process"
 msgstr ""
 
-#: src/ui/pages/processes/mod.rs:980
+#: src/ui/pages/processes/mod.rs:970
 #: data/resources/ui/dialogs/process_dialog.ui:186
-#: data/resources/ui/dialogs/settings_dialog.ui:210
+#: data/resources/ui/dialogs/settings_dialog.ui:205
 msgid "Process ID"
 msgstr ""
 
-#: src/ui/pages/processes/mod.rs:1033
+#: src/ui/pages/processes/mod.rs:1023
 #: data/resources/ui/dialogs/process_dialog.ui:213
-#: data/resources/ui/dialogs/settings_dialog.ui:215
+#: data/resources/ui/dialogs/settings_dialog.ui:210
 msgid "User"
 msgstr ""
 
-#: src/ui/pages/processes/mod.rs:1708
+#: src/ui/pages/processes/mod.rs:1698
 #: data/resources/ui/dialogs/process_dialog.ui:154
-#: data/resources/ui/dialogs/settings_dialog.ui:270
+#: data/resources/ui/dialogs/settings_dialog.ui:265
 msgid "Total CPU Time"
 msgstr ""
 
-#: src/ui/pages/processes/mod.rs:1767
+#: src/ui/pages/processes/mod.rs:1757
 #: data/resources/ui/dialogs/process_dialog.ui:163
-#: data/resources/ui/dialogs/settings_dialog.ui:275
+#: data/resources/ui/dialogs/settings_dialog.ui:270
 msgid "User CPU Time"
 msgstr ""
 
-#: src/ui/pages/processes/mod.rs:1826
+#: src/ui/pages/processes/mod.rs:1816
 #: data/resources/ui/dialogs/process_dialog.ui:172
-#: data/resources/ui/dialogs/settings_dialog.ui:280
+#: data/resources/ui/dialogs/settings_dialog.ui:275
 msgid "System CPU Time"
 msgstr ""
 
-#: src/ui/pages/processes/mod.rs:1885
+#: src/ui/pages/processes/mod.rs:1875
 #: data/resources/ui/dialogs/process_options_dialog.ui:87
-#: data/resources/ui/dialogs/settings_dialog.ui:285
+#: data/resources/ui/dialogs/settings_dialog.ui:280
 msgid "Priority"
 msgstr ""
 
-#: src/ui/pages/processes/mod.rs:2019
+#: src/ui/pages/processes/mod.rs:2009
 msgid "End process?"
 msgid_plural "End {} processes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/pages/processes/mod.rs:2025
+#: src/ui/pages/processes/mod.rs:2015
 msgid "Halt process?"
 msgid_plural "Halt {} processes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/pages/processes/mod.rs:2031 src/ui/pages/processes/mod.rs:2037
+#: src/ui/pages/processes/mod.rs:2021 src/ui/pages/processes/mod.rs:2027
 msgid "Kill process?"
 msgid_plural "Kill {} processes?"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/pages/processes/mod.rs:2048
+#: src/ui/pages/processes/mod.rs:2038
 msgid ""
 "Halting a process can come with serious risks such as losing data and "
 "security implications. Use with caution."
 msgstr ""
 
-#: src/ui/pages/processes/mod.rs:2049
+#: src/ui/pages/processes/mod.rs:2039
 msgid ""
 "Killing a process can come with serious risks such as losing data and "
 "security implications. Use with caution."
 msgstr ""
 
-#: src/ui/pages/processes/mod.rs:2057 data/resources/ui/pages/processes.ui:10
+#: src/ui/pages/processes/mod.rs:2047 data/resources/ui/pages/processes.ui:10
 #: data/resources/ui/pages/processes.ui:46
 msgid "Halt Process"
 msgstr ""
 
-#: src/ui/pages/processes/mod.rs:2058 data/resources/ui/pages/processes.ui:6
+#: src/ui/pages/processes/mod.rs:2048 data/resources/ui/pages/processes.ui:6
 #: data/resources/ui/pages/processes.ui:42
 msgid "Kill Process"
 msgstr ""
 
-#: src/ui/pages/processes/mod.rs:2059 data/resources/ui/pages/processes.ui:14
+#: src/ui/pages/processes/mod.rs:2049 data/resources/ui/pages/processes.ui:14
 #: data/resources/ui/pages/processes.ui:50
 msgid "Continue Process"
 msgstr ""
 
-#: src/ui/window.rs:309
+#: src/ui/window.rs:458
 msgid "GPU {}"
 msgstr ""
 
-#: src/ui/window.rs:341
+#: src/ui/window.rs:488
 msgid "NPU {}"
 msgstr ""
 
-#: src/ui/window.rs:1039
+#: src/ui/window.rs:1154
 msgid "Successfully adjusted {}"
 msgstr ""
 
-#: src/ui/window.rs:1040
+#: src/ui/window.rs:1155
 msgid "There was a problem adjusting {}"
 msgstr ""
 
-#: src/ui/window.rs:1120
+#: src/ui/window.rs:1237
 msgid "Successfully ended {}"
 msgstr ""
 
-#: src/ui/window.rs:1121
+#: src/ui/window.rs:1238
 msgid "Successfully halted {}"
 msgstr ""
 
-#: src/ui/window.rs:1122
+#: src/ui/window.rs:1239
 msgid "Successfully killed {}"
 msgstr ""
 
-#: src/ui/window.rs:1123
+#: src/ui/window.rs:1240
 msgid "Successfully continued {}"
 msgstr ""
 
-#: src/ui/window.rs:1130
+#: src/ui/window.rs:1247
 msgid "Successfully ended the process"
 msgid_plural "Successfully ended {} processes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/window.rs:1136
+#: src/ui/window.rs:1253
 msgid "Successfully halted the process"
 msgid_plural "Successfully halted {} processes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/window.rs:1142
+#: src/ui/window.rs:1259
 msgid "Successfully killed the process"
 msgid_plural "Successfully killed {} processes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/window.rs:1148
+#: src/ui/window.rs:1265
 msgid "Successfully continued the process"
 msgid_plural "Successfully continued {} processes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/window.rs:1159
+#: src/ui/window.rs:1276
 msgid "There was a problem ending a process"
 msgid_plural "There were problems ending {} processes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/window.rs:1165
+#: src/ui/window.rs:1282
 msgid "There was a problem halting a process"
 msgid_plural "There were problems halting {} processes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/window.rs:1171
+#: src/ui/window.rs:1288
 msgid "There was a problem killing a process"
 msgid_plural "There were problems killing {} processes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/window.rs:1177
+#: src/ui/window.rs:1294
 msgid "There was a problem continuing a process"
 msgid_plural "There were problems continuing {} processes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/ui/window.rs:1187
+#: src/ui/window.rs:1304
 msgid "There was a problem ending {}"
 msgstr ""
 
-#: src/ui/window.rs:1188
+#: src/ui/window.rs:1305
 msgid "There was a problem halting {}"
 msgstr ""
 
-#: src/ui/window.rs:1189
+#: src/ui/window.rs:1306
 msgid "There was a problem killing {}"
 msgstr ""
 
-#: src/ui/window.rs:1190
+#: src/ui/window.rs:1307
 msgid "There was a problem continuing {}"
 msgstr ""
 
@@ -657,588 +664,588 @@ msgstr ""
 msgid "System Processes"
 msgstr ""
 
-#: src/utils/battery.rs:77
+#: src/utils/battery.rs:90
 msgid "Charging"
 msgstr ""
 
-#: src/utils/battery.rs:78
+#: src/utils/battery.rs:91
 msgid "Discharging"
 msgstr ""
 
-#: src/utils/battery.rs:79
+#: src/utils/battery.rs:92
 msgid "Empty"
 msgstr ""
 
-#: src/utils/battery.rs:80
+#: src/utils/battery.rs:93
 msgid "Full"
 msgstr ""
 
-#: src/utils/battery.rs:81
+#: src/utils/battery.rs:94
 msgid "Unknown"
 msgstr ""
 
-#: src/utils/battery.rs:127
+#: src/utils/battery.rs:140
 msgid "Nickel-Metal Hydride"
 msgstr ""
 
-#: src/utils/battery.rs:128
+#: src/utils/battery.rs:141
 msgid "Nickel-Cadmium"
 msgstr ""
 
-#: src/utils/battery.rs:129
+#: src/utils/battery.rs:142
 msgid "Nickel-Zinc"
 msgstr ""
 
-#: src/utils/battery.rs:130
+#: src/utils/battery.rs:143
 msgid "Lead-Acid"
 msgstr ""
 
-#: src/utils/battery.rs:131
+#: src/utils/battery.rs:144
 msgid "Lithium-Ion"
 msgstr ""
 
-#: src/utils/battery.rs:132
+#: src/utils/battery.rs:145
 msgid "Lithium Iron Phosphate"
 msgstr ""
 
-#: src/utils/battery.rs:133
+#: src/utils/battery.rs:146
 msgid "Lithium Polymer"
 msgstr ""
 
-#: src/utils/battery.rs:135
+#: src/utils/battery.rs:148
 msgid "Rechargeable Alkaline Managanese"
 msgstr ""
 
-#: src/utils/battery.rs:229
+#: src/utils/battery.rs:258
 msgid "{} Battery"
 msgstr ""
 
-#: src/utils/battery.rs:231
+#: src/utils/battery.rs:260
 msgid "Battery"
 msgstr ""
 
-#: src/utils/drive.rs:81 src/utils/drive.rs:152
+#: src/utils/drive.rs:100 src/utils/drive.rs:179
 msgid "CD/DVD/Blu-ray Drive"
 msgstr ""
 
-#: src/utils/drive.rs:82
+#: src/utils/drive.rs:101
 msgid "eMMC Storage"
 msgstr ""
 
-#: src/utils/drive.rs:83
+#: src/utils/drive.rs:102
 msgid "Flash Storage"
 msgstr ""
 
-#: src/utils/drive.rs:84 src/utils/drive.rs:153
+#: src/utils/drive.rs:103 src/utils/drive.rs:180
 msgid "Floppy Drive"
 msgstr ""
 
-#: src/utils/drive.rs:85
+#: src/utils/drive.rs:104
 msgid "Hard Disk Drive"
 msgstr ""
 
-#: src/utils/drive.rs:86
+#: src/utils/drive.rs:105
 msgid "Loop Device"
 msgstr ""
 
-#: src/utils/drive.rs:87
+#: src/utils/drive.rs:106
 msgid "Mapped Device"
 msgstr ""
 
-#: src/utils/drive.rs:88
+#: src/utils/drive.rs:107
 msgid "NVMe Drive"
 msgstr ""
 
-#: src/utils/drive.rs:90
+#: src/utils/drive.rs:109
 msgid "Software Raid"
 msgstr ""
 
-#: src/utils/drive.rs:91
+#: src/utils/drive.rs:110
 msgid "RAM Disk"
 msgstr ""
 
-#: src/utils/drive.rs:92
+#: src/utils/drive.rs:111
 msgid "Solid State Drive"
 msgstr ""
 
-#: src/utils/drive.rs:93
+#: src/utils/drive.rs:112
 msgid "ZFS Volume"
 msgstr ""
 
-#: src/utils/drive.rs:94
+#: src/utils/drive.rs:113
 msgid "Compressed RAM Disk (zram)"
 msgstr ""
 
-#: src/utils/drive.rs:154
+#: src/utils/drive.rs:181
 msgid "{} Loop Device"
 msgstr ""
 
-#: src/utils/drive.rs:155
+#: src/utils/drive.rs:182
 msgid "{} Mapped Device"
 msgstr ""
 
-#: src/utils/drive.rs:156
+#: src/utils/drive.rs:183
 msgid "{} RAID"
 msgstr ""
 
-#: src/utils/drive.rs:157
+#: src/utils/drive.rs:184
 msgid "{} RAM Disk"
 msgstr ""
 
-#: src/utils/drive.rs:158
+#: src/utils/drive.rs:185
 msgid "{} zram Device"
 msgstr ""
 
-#: src/utils/drive.rs:159
+#: src/utils/drive.rs:186
 msgid "{} ZFS Volume"
 msgstr ""
 
-#: src/utils/drive.rs:160
+#: src/utils/drive.rs:187
 msgid "{} Drive"
 msgstr ""
 
-#: src/utils/network.rs:116
+#: src/utils/network.rs:124
 msgid "Bluetooth Tether"
 msgstr ""
 
-#: src/utils/network.rs:117
+#: src/utils/network.rs:125
 msgid "Network Bridge"
 msgstr ""
 
-#: src/utils/network.rs:118
+#: src/utils/network.rs:126
 msgid "Ethernet Connection"
 msgstr ""
 
-#: src/utils/network.rs:119
+#: src/utils/network.rs:127
 msgid "Docker Bridge"
 msgstr ""
 
-#: src/utils/network.rs:120
+#: src/utils/network.rs:128
 msgid "InfiniBand Connection"
 msgstr ""
 
-#: src/utils/network.rs:121
+#: src/utils/network.rs:129
 msgid "Serial Line IP Connection"
 msgstr ""
 
-#: src/utils/network.rs:122
+#: src/utils/network.rs:130
 msgid "Virtual Ethernet Device"
 msgstr ""
 
-#: src/utils/network.rs:123
+#: src/utils/network.rs:131
 msgid "VM Network Bridge"
 msgstr ""
 
-#: src/utils/network.rs:124
+#: src/utils/network.rs:132
 msgid "VPN Tunnel"
 msgstr ""
 
-#: src/utils/network.rs:125
+#: src/utils/network.rs:133
 msgid "VPN Tunnel (WireGuard)"
 msgstr ""
 
-#: src/utils/network.rs:126
+#: src/utils/network.rs:134
 msgid "Wi-Fi Connection"
 msgstr ""
 
-#: src/utils/network.rs:127
+#: src/utils/network.rs:135
 msgid "WWAN Connection"
 msgstr ""
 
-#: src/utils/units.rs:59
+#: src/utils/units.rs:76
 msgid "{} K"
 msgstr ""
 
-#: src/utils/units.rs:61
+#: src/utils/units.rs:78
 msgid "{} °C"
 msgstr ""
 
-#: src/utils/units.rs:63
+#: src/utils/units.rs:80
 msgid "{} °F"
 msgstr ""
 
-#: src/utils/units.rs:81 src/utils/units.rs:95 src/utils/units.rs:115
-#: src/utils/units.rs:129
+#: src/utils/units.rs:98 src/utils/units.rs:112 src/utils/units.rs:132
+#: src/utils/units.rs:146
 msgid "{} B"
 msgstr ""
 
-#: src/utils/units.rs:82 src/utils/units.rs:96
+#: src/utils/units.rs:99 src/utils/units.rs:113
 msgid "{} kB"
 msgstr ""
 
-#: src/utils/units.rs:83 src/utils/units.rs:97
+#: src/utils/units.rs:100 src/utils/units.rs:114
 msgid "{} MB"
 msgstr ""
 
-#: src/utils/units.rs:84 src/utils/units.rs:98
+#: src/utils/units.rs:101 src/utils/units.rs:115
 msgid "{} GB"
 msgstr ""
 
-#: src/utils/units.rs:85 src/utils/units.rs:99
+#: src/utils/units.rs:102 src/utils/units.rs:116
 msgid "{} TB"
 msgstr ""
 
-#: src/utils/units.rs:86 src/utils/units.rs:100
+#: src/utils/units.rs:103 src/utils/units.rs:117
 msgid "{} PB"
 msgstr ""
 
-#: src/utils/units.rs:87 src/utils/units.rs:101
+#: src/utils/units.rs:104 src/utils/units.rs:118
 msgid "{} EB"
 msgstr ""
 
-#: src/utils/units.rs:88 src/utils/units.rs:102
+#: src/utils/units.rs:105 src/utils/units.rs:119
 msgid "{} ZB"
 msgstr ""
 
-#: src/utils/units.rs:89 src/utils/units.rs:103
+#: src/utils/units.rs:106 src/utils/units.rs:120
 msgid "{} YB"
 msgstr ""
 
-#: src/utils/units.rs:90 src/utils/units.rs:104
+#: src/utils/units.rs:107 src/utils/units.rs:121
 msgid "{} RB"
 msgstr ""
 
-#: src/utils/units.rs:91 src/utils/units.rs:105
+#: src/utils/units.rs:108 src/utils/units.rs:122
 msgid "{} QB"
 msgstr ""
 
-#: src/utils/units.rs:116 src/utils/units.rs:130
+#: src/utils/units.rs:133 src/utils/units.rs:147
 msgid "{} KiB"
 msgstr ""
 
-#: src/utils/units.rs:117 src/utils/units.rs:131
+#: src/utils/units.rs:134 src/utils/units.rs:148
 msgid "{} MiB"
 msgstr ""
 
-#: src/utils/units.rs:118 src/utils/units.rs:132
+#: src/utils/units.rs:135 src/utils/units.rs:149
 msgid "{} GiB"
 msgstr ""
 
-#: src/utils/units.rs:119 src/utils/units.rs:133
+#: src/utils/units.rs:136 src/utils/units.rs:150
 msgid "{} TiB"
 msgstr ""
 
-#: src/utils/units.rs:120 src/utils/units.rs:134
+#: src/utils/units.rs:137 src/utils/units.rs:151
 msgid "{} PiB"
 msgstr ""
 
-#: src/utils/units.rs:121 src/utils/units.rs:135
+#: src/utils/units.rs:138 src/utils/units.rs:152
 msgid "{} EiB"
 msgstr ""
 
-#: src/utils/units.rs:122 src/utils/units.rs:136
+#: src/utils/units.rs:139 src/utils/units.rs:153
 msgid "{} ZiB"
 msgstr ""
 
-#: src/utils/units.rs:123 src/utils/units.rs:137
+#: src/utils/units.rs:140 src/utils/units.rs:154
 msgid "{} YiB"
 msgstr ""
 
-#: src/utils/units.rs:124 src/utils/units.rs:138
+#: src/utils/units.rs:141 src/utils/units.rs:155
 msgid "{} RiB"
 msgstr ""
 
-#: src/utils/units.rs:125 src/utils/units.rs:139
+#: src/utils/units.rs:142 src/utils/units.rs:156
 msgid "{} QiB"
 msgstr ""
 
-#: src/utils/units.rs:166 src/utils/units.rs:183
+#: src/utils/units.rs:183 src/utils/units.rs:200
 msgid "{} B/s"
 msgstr ""
 
-#: src/utils/units.rs:167
+#: src/utils/units.rs:184
 msgid "{} kB/s"
 msgstr ""
 
-#: src/utils/units.rs:168
+#: src/utils/units.rs:185
 msgid "{} MB/s"
 msgstr ""
 
-#: src/utils/units.rs:169
+#: src/utils/units.rs:186
 msgid "{} GB/s"
 msgstr ""
 
-#: src/utils/units.rs:170
+#: src/utils/units.rs:187
 msgid "{} TB/s"
 msgstr ""
 
-#: src/utils/units.rs:171
+#: src/utils/units.rs:188
 msgid "{} PB/s"
 msgstr ""
 
-#: src/utils/units.rs:172
+#: src/utils/units.rs:189
 msgid "{} EB/s"
 msgstr ""
 
-#: src/utils/units.rs:173
+#: src/utils/units.rs:190
 msgid "{} ZB/s"
 msgstr ""
 
-#: src/utils/units.rs:174
+#: src/utils/units.rs:191
 msgid "{} YB/s"
 msgstr ""
 
-#: src/utils/units.rs:175
+#: src/utils/units.rs:192
 msgid "{} RB/s"
 msgstr ""
 
-#: src/utils/units.rs:176
+#: src/utils/units.rs:193
 msgid "{} QB/s"
 msgstr ""
 
-#: src/utils/units.rs:184
+#: src/utils/units.rs:201
 msgid "{} KiB/s"
 msgstr ""
 
-#: src/utils/units.rs:185
+#: src/utils/units.rs:202
 msgid "{} MiB/s"
 msgstr ""
 
-#: src/utils/units.rs:186
+#: src/utils/units.rs:203
 msgid "{} GiB/s"
 msgstr ""
 
-#: src/utils/units.rs:187
+#: src/utils/units.rs:204
 msgid "{} TiB/s"
 msgstr ""
 
-#: src/utils/units.rs:188
+#: src/utils/units.rs:205
 msgid "{} PiB/s"
 msgstr ""
 
-#: src/utils/units.rs:189
+#: src/utils/units.rs:206
 msgid "{} EiB/s"
 msgstr ""
 
-#: src/utils/units.rs:190
+#: src/utils/units.rs:207
 msgid "{} ZiB/s"
 msgstr ""
 
-#: src/utils/units.rs:191
+#: src/utils/units.rs:208
 msgid "{} YiB/s"
 msgstr ""
 
-#: src/utils/units.rs:192
+#: src/utils/units.rs:209
 msgid "{} RiB/s"
 msgstr ""
 
-#: src/utils/units.rs:193
+#: src/utils/units.rs:210
 msgid "{} QiB/s"
 msgstr ""
 
-#: src/utils/units.rs:200 src/utils/units.rs:217
+#: src/utils/units.rs:217 src/utils/units.rs:234
 msgid "{} b/s"
 msgstr ""
 
-#: src/utils/units.rs:201
+#: src/utils/units.rs:218
 msgid "{} kb/s"
 msgstr ""
 
-#: src/utils/units.rs:202
+#: src/utils/units.rs:219
 msgid "{} Mb/s"
 msgstr ""
 
-#: src/utils/units.rs:203
+#: src/utils/units.rs:220
 msgid "{} Gb/s"
 msgstr ""
 
-#: src/utils/units.rs:204
+#: src/utils/units.rs:221
 msgid "{} Tb/s"
 msgstr ""
 
-#: src/utils/units.rs:205
+#: src/utils/units.rs:222
 msgid "{} Pb/s"
 msgstr ""
 
-#: src/utils/units.rs:206
+#: src/utils/units.rs:223
 msgid "{} Eb/s"
 msgstr ""
 
-#: src/utils/units.rs:207
+#: src/utils/units.rs:224
 msgid "{} Zb/s"
 msgstr ""
 
-#: src/utils/units.rs:208
+#: src/utils/units.rs:225
 msgid "{} Yb/s"
 msgstr ""
 
-#: src/utils/units.rs:209
+#: src/utils/units.rs:226
 msgid "{} Rb/s"
 msgstr ""
 
-#: src/utils/units.rs:210
+#: src/utils/units.rs:227
 msgid "{} Qb/s"
 msgstr ""
 
-#: src/utils/units.rs:218
+#: src/utils/units.rs:235
 msgid "{} Kib/s"
 msgstr ""
 
-#: src/utils/units.rs:219
+#: src/utils/units.rs:236
 msgid "{} Mib/s"
 msgstr ""
 
-#: src/utils/units.rs:220
+#: src/utils/units.rs:237
 msgid "{} Gib/s"
 msgstr ""
 
-#: src/utils/units.rs:221
+#: src/utils/units.rs:238
 msgid "{} Tib/s"
 msgstr ""
 
-#: src/utils/units.rs:222
+#: src/utils/units.rs:239
 msgid "{} Pib/s"
 msgstr ""
 
-#: src/utils/units.rs:223
+#: src/utils/units.rs:240
 msgid "{} Eib/s"
 msgstr ""
 
-#: src/utils/units.rs:224
+#: src/utils/units.rs:241
 msgid "{} Zib/s"
 msgstr ""
 
-#: src/utils/units.rs:225
+#: src/utils/units.rs:242
 msgid "{} Yib/s"
 msgstr ""
 
-#: src/utils/units.rs:226
+#: src/utils/units.rs:243
 msgid "{} Rib/s"
 msgstr ""
 
-#: src/utils/units.rs:227
+#: src/utils/units.rs:244
 msgid "{} Qib/s"
 msgstr ""
 
-#: src/utils/units.rs:234
+#: src/utils/units.rs:251
 msgid "{} Hz"
 msgstr ""
 
-#: src/utils/units.rs:235
+#: src/utils/units.rs:252
 msgid "{} kHz"
 msgstr ""
 
-#: src/utils/units.rs:236
+#: src/utils/units.rs:253
 msgid "{} MHz"
 msgstr ""
 
-#: src/utils/units.rs:237
+#: src/utils/units.rs:254
 msgid "{} GHz"
 msgstr ""
 
-#: src/utils/units.rs:238
+#: src/utils/units.rs:255
 msgid "{} THz"
 msgstr ""
 
-#: src/utils/units.rs:239
+#: src/utils/units.rs:256
 msgid "{} PHz"
 msgstr ""
 
-#: src/utils/units.rs:240
+#: src/utils/units.rs:257
 msgid "{} EHz"
 msgstr ""
 
-#: src/utils/units.rs:241
+#: src/utils/units.rs:258
 msgid "{} ZHz"
 msgstr ""
 
-#: src/utils/units.rs:242
+#: src/utils/units.rs:259
 msgid "{} YHz"
 msgstr ""
 
-#: src/utils/units.rs:243
+#: src/utils/units.rs:260
 msgid "{} RHz"
 msgstr ""
 
-#: src/utils/units.rs:244
+#: src/utils/units.rs:261
 msgid "{} QHz"
 msgstr ""
 
-#: src/utils/units.rs:251
+#: src/utils/units.rs:268
 msgid "{} W"
 msgstr ""
 
-#: src/utils/units.rs:252
+#: src/utils/units.rs:269
 msgid "{} kW"
 msgstr ""
 
-#: src/utils/units.rs:253
+#: src/utils/units.rs:270
 msgid "{} MW"
 msgstr ""
 
-#: src/utils/units.rs:254
+#: src/utils/units.rs:271
 msgid "{} GW"
 msgstr ""
 
-#: src/utils/units.rs:255
+#: src/utils/units.rs:272
 msgid "{} TW"
 msgstr ""
 
-#: src/utils/units.rs:256
+#: src/utils/units.rs:273
 msgid "{} PW"
 msgstr ""
 
-#: src/utils/units.rs:257
+#: src/utils/units.rs:274
 msgid "{} EW"
 msgstr ""
 
-#: src/utils/units.rs:258
+#: src/utils/units.rs:275
 msgid "{} ZW"
 msgstr ""
 
-#: src/utils/units.rs:259
+#: src/utils/units.rs:276
 msgid "{} YW"
 msgstr ""
 
-#: src/utils/units.rs:260
+#: src/utils/units.rs:277
 msgid "{} RW"
 msgstr ""
 
-#: src/utils/units.rs:261
+#: src/utils/units.rs:278
 msgid "{} QW"
 msgstr ""
 
-#: src/utils/units.rs:270 src/utils/units.rs:284
+#: src/utils/units.rs:287 src/utils/units.rs:301
 msgid "{} Wh"
 msgstr ""
 
-#: src/utils/units.rs:271 src/utils/units.rs:285
+#: src/utils/units.rs:288 src/utils/units.rs:302
 msgid "{} kWh"
 msgstr ""
 
-#: src/utils/units.rs:272 src/utils/units.rs:286
+#: src/utils/units.rs:289 src/utils/units.rs:303
 msgid "{} MWh"
 msgstr ""
 
-#: src/utils/units.rs:273 src/utils/units.rs:287
+#: src/utils/units.rs:290 src/utils/units.rs:304
 msgid "{} GWh"
 msgstr ""
 
-#: src/utils/units.rs:274 src/utils/units.rs:288
+#: src/utils/units.rs:291 src/utils/units.rs:305
 msgid "{} TWh"
 msgstr ""
 
-#: src/utils/units.rs:275 src/utils/units.rs:289
+#: src/utils/units.rs:292 src/utils/units.rs:306
 msgid "{} PWh"
 msgstr ""
 
-#: src/utils/units.rs:276 src/utils/units.rs:290
+#: src/utils/units.rs:293 src/utils/units.rs:307
 msgid "{} EWh"
 msgstr ""
 
-#: src/utils/units.rs:277 src/utils/units.rs:291
+#: src/utils/units.rs:294 src/utils/units.rs:308
 msgid "{} ZWh"
 msgstr ""
 
-#: src/utils/units.rs:278 src/utils/units.rs:292
+#: src/utils/units.rs:295 src/utils/units.rs:309
 msgid "{} YWh"
 msgstr ""
 
-#: src/utils/units.rs:279 src/utils/units.rs:293
+#: src/utils/units.rs:296 src/utils/units.rs:310
 msgid "{} RWh"
 msgstr ""
 
-#: src/utils/units.rs:280 src/utils/units.rs:294
+#: src/utils/units.rs:297 src/utils/units.rs:311
 msgid "{} QWh"
 msgstr ""
 
@@ -1309,6 +1316,14 @@ msgstr ""
 msgid "About Resources"
 msgstr ""
 
+#: data/resources/ui/window.ui:88 data/resources/ui/window.ui:128
+msgid "Search"
+msgstr ""
+
+#: data/resources/ui/window.ui:90 data/resources/ui/window.ui:130
+msgid "Toggle search field"
+msgstr ""
+
 #: data/resources/ui/dialogs/app_dialog.ui:7
 msgid "App Information"
 msgstr ""
@@ -1324,10 +1339,10 @@ msgstr ""
 
 #: data/resources/ui/dialogs/app_dialog.ui:174
 #: data/resources/ui/dialogs/process_dialog.ui:179
-#: data/resources/ui/pages/battery.ui:33 data/resources/ui/pages/cpu.ui:89
-#: data/resources/ui/pages/drive.ui:54 data/resources/ui/pages/gpu.ui:80
+#: data/resources/ui/pages/battery.ui:33 data/resources/ui/pages/cpu.ui:83
+#: data/resources/ui/pages/drive.ui:54 data/resources/ui/pages/gpu.ui:74
 #: data/resources/ui/pages/memory.ui:42 data/resources/ui/pages/network.ui:51
-#: data/resources/ui/pages/npu.ui:74
+#: data/resources/ui/pages/npu.ui:68
 msgid "Properties"
 msgstr ""
 
@@ -1503,89 +1518,85 @@ msgid "Graph Data Points"
 msgstr ""
 
 #: data/resources/ui/dialogs/settings_dialog.ui:86
-msgid "Show Search Fields on Launch"
-msgstr ""
-
-#: data/resources/ui/dialogs/settings_dialog.ui:91
 msgid "Show Usage Details in Sidebar"
 msgstr ""
 
-#: data/resources/ui/dialogs/settings_dialog.ui:92
+#: data/resources/ui/dialogs/settings_dialog.ui:87
 msgid "If enabled, the usage along with other information will be displayed"
 msgstr ""
 
-#: data/resources/ui/dialogs/settings_dialog.ui:97
+#: data/resources/ui/dialogs/settings_dialog.ui:92
 msgid "Show Device Descriptions in Sidebar"
 msgstr ""
 
-#: data/resources/ui/dialogs/settings_dialog.ui:98
+#: data/resources/ui/dialogs/settings_dialog.ui:93
 msgid ""
 "If enabled, a device identifier like its name or device type will be "
 "displayed"
 msgstr ""
 
-#: data/resources/ui/dialogs/settings_dialog.ui:103
+#: data/resources/ui/dialogs/settings_dialog.ui:98
 msgid "Sidebar Meter Type"
 msgstr ""
 
-#: data/resources/ui/dialogs/settings_dialog.ui:107
+#: data/resources/ui/dialogs/settings_dialog.ui:102
 msgid "Bar"
 msgstr ""
 
-#: data/resources/ui/dialogs/settings_dialog.ui:108
+#: data/resources/ui/dialogs/settings_dialog.ui:103
 msgid "Graph"
 msgstr ""
 
-#: data/resources/ui/dialogs/settings_dialog.ui:116
+#: data/resources/ui/dialogs/settings_dialog.ui:111
 msgid "Normalize Processor Usage"
 msgstr ""
 
-#: data/resources/ui/dialogs/settings_dialog.ui:117
+#: data/resources/ui/dialogs/settings_dialog.ui:112
 msgid ""
 "If enabled, the total usage of all cores will be divided by the amount of "
 "cores"
 msgstr ""
 
-#: data/resources/ui/dialogs/settings_dialog.ui:130
-#: data/resources/ui/dialogs/settings_dialog.ui:207
+#: data/resources/ui/dialogs/settings_dialog.ui:125
+#: data/resources/ui/dialogs/settings_dialog.ui:202
 msgid "Information Columns"
 msgstr ""
 
-#: data/resources/ui/dialogs/settings_dialog.ui:196
+#: data/resources/ui/dialogs/settings_dialog.ui:191
 #: data/resources/ui/pages/cpu.ui:22 data/resources/ui/pages/processes.ui:56
 msgid "Options"
 msgstr ""
 
-#: data/resources/ui/dialogs/settings_dialog.ui:199
+#: data/resources/ui/dialogs/settings_dialog.ui:194
 msgid "Show Niceness Values"
 msgstr ""
 
-#: data/resources/ui/dialogs/settings_dialog.ui:200
+#: data/resources/ui/dialogs/settings_dialog.ui:195
 msgid ""
 "Display priorities as niceness to allow for more fine-grained adjustments"
 msgstr ""
 
-#: data/resources/ui/dialogs/settings_dialog.ui:300
+#: data/resources/ui/dialogs/settings_dialog.ui:295
 msgid "Devices"
 msgstr ""
 
-#: data/resources/ui/dialogs/settings_dialog.ui:303
+#: data/resources/ui/dialogs/settings_dialog.ui:298
 msgid "Drives"
 msgstr ""
 
-#: data/resources/ui/dialogs/settings_dialog.ui:306
+#: data/resources/ui/dialogs/settings_dialog.ui:301
 msgid "Show Virtual Drives"
 msgstr ""
 
-#: data/resources/ui/dialogs/settings_dialog.ui:307
+#: data/resources/ui/dialogs/settings_dialog.ui:302
 msgid "Virtual drives are for example ZFS volumes or mapped devices"
 msgstr ""
 
-#: data/resources/ui/dialogs/settings_dialog.ui:317
+#: data/resources/ui/dialogs/settings_dialog.ui:312
 msgid "Show Virtual Network Interfaces"
 msgstr ""
 
-#: data/resources/ui/dialogs/settings_dialog.ui:318
+#: data/resources/ui/dialogs/settings_dialog.ui:313
 msgid "Virtual network interfaces are for example bridges or VPN tunnels"
 msgstr ""
 
@@ -1594,22 +1605,12 @@ msgstr ""
 msgid "Information"
 msgstr ""
 
-#: data/resources/ui/pages/applications.ui:80
+#: data/resources/ui/pages/applications.ui:57
 msgid "Search applications"
 msgstr ""
 
-#: data/resources/ui/pages/applications.ui:98
-#: data/resources/ui/pages/processes.ui:144
-msgid "Search"
-msgstr ""
-
-#: data/resources/ui/pages/applications.ui:100
-#: data/resources/ui/pages/processes.ui:146
-msgid "Toggle search field"
-msgstr ""
-
-#: data/resources/ui/pages/applications.ui:116
-#: data/resources/ui/pages/applications.ui:118
+#: data/resources/ui/pages/applications.ui:87
+#: data/resources/ui/pages/applications.ui:89
 msgid "Show App Information"
 msgstr ""
 
@@ -1629,8 +1630,8 @@ msgstr ""
 msgid "Technology"
 msgstr ""
 
-#: data/resources/ui/pages/battery.ui:72 data/resources/ui/pages/gpu.ui:87
-#: data/resources/ui/pages/network.ui:58 data/resources/ui/pages/npu.ui:81
+#: data/resources/ui/pages/battery.ui:72 data/resources/ui/pages/gpu.ui:81
+#: data/resources/ui/pages/network.ui:58 data/resources/ui/pages/npu.ui:75
 msgid "Manufacturer"
 msgstr ""
 
@@ -1651,32 +1652,27 @@ msgstr ""
 msgid "Sensors"
 msgstr ""
 
-#: data/resources/ui/pages/cpu.ui:82 data/resources/ui/pages/gpu.ui:69
-#: data/resources/ui/pages/npu.ui:63
-msgid "Temperature"
-msgstr ""
-
-#: data/resources/ui/pages/cpu.ui:96
+#: data/resources/ui/pages/cpu.ui:90
 msgid "Max Frequency"
 msgstr ""
 
-#: data/resources/ui/pages/cpu.ui:105
+#: data/resources/ui/pages/cpu.ui:99
 msgid "Logical Cores"
 msgstr ""
 
-#: data/resources/ui/pages/cpu.ui:114
+#: data/resources/ui/pages/cpu.ui:108
 msgid "Physical Cores"
 msgstr ""
 
-#: data/resources/ui/pages/cpu.ui:123
+#: data/resources/ui/pages/cpu.ui:117
 msgid "Sockets"
 msgstr ""
 
-#: data/resources/ui/pages/cpu.ui:132
+#: data/resources/ui/pages/cpu.ui:126
 msgid "Virtualization"
 msgstr ""
 
-#: data/resources/ui/pages/cpu.ui:141
+#: data/resources/ui/pages/cpu.ui:135
 msgid "Architecture"
 msgstr ""
 
@@ -1704,6 +1700,10 @@ msgstr ""
 msgid "Removable"
 msgstr ""
 
+#: data/resources/ui/pages/drive.ui:102 data/resources/ui/pages/gpu.ui:113
+msgid "Link"
+msgstr ""
+
 #: data/resources/ui/pages/gpu.ui:37
 msgid "GPU Frequency"
 msgstr ""
@@ -1712,16 +1712,16 @@ msgstr ""
 msgid "Video Memory Frequency"
 msgstr ""
 
-#: data/resources/ui/pages/gpu.ui:96 data/resources/ui/pages/npu.ui:90
+#: data/resources/ui/pages/gpu.ui:90 data/resources/ui/pages/npu.ui:84
 msgid "PCI Slot"
 msgstr ""
 
-#: data/resources/ui/pages/gpu.ui:105 data/resources/ui/pages/network.ui:67
-#: data/resources/ui/pages/npu.ui:99
+#: data/resources/ui/pages/gpu.ui:99 data/resources/ui/pages/network.ui:67
+#: data/resources/ui/pages/npu.ui:93
 msgid "Driver Used"
 msgstr ""
 
-#: data/resources/ui/pages/gpu.ui:114 data/resources/ui/pages/npu.ui:108
+#: data/resources/ui/pages/gpu.ui:108 data/resources/ui/pages/npu.ui:102
 msgid "Max Power Cap"
 msgstr ""
 
@@ -1788,16 +1788,16 @@ msgstr ""
 msgid "Continue Processes"
 msgstr ""
 
-#: data/resources/ui/pages/processes.ui:126
+#: data/resources/ui/pages/processes.ui:103
 msgid "Search processes"
 msgstr ""
 
-#: data/resources/ui/pages/processes.ui:162
-#: data/resources/ui/pages/processes.ui:164
+#: data/resources/ui/pages/processes.ui:133
+#: data/resources/ui/pages/processes.ui:135
 msgid "Show Process Options"
 msgstr ""
 
-#: data/resources/ui/pages/processes.ui:175
-#: data/resources/ui/pages/processes.ui:177
+#: data/resources/ui/pages/processes.ui:146
+#: data/resources/ui/pages/processes.ui:148
 msgid "Show Process Information"
 msgstr ""

--- a/src/ui/pages/drive.rs
+++ b/src/ui/pages/drive.rs
@@ -423,8 +423,10 @@ impl ResDrive {
             imp.removable.set_subtitle(&i18n("N/A"));
         }
 
-        if let Some(link) = link {
+        if let Ok(link) = link {
             imp.link.set_subtitle(&link.to_string());
+        } else {
+            imp.link.set_subtitle(&i18n("N/A"));
         }
         self.set_property(
             "tab_usage_string",

--- a/src/ui/pages/drive.rs
+++ b/src/ui/pages/drive.rs
@@ -428,6 +428,7 @@ impl ResDrive {
         } else {
             imp.link.set_subtitle(&i18n("N/A"));
         }
+
         self.set_property(
             "tab_usage_string",
             // Translators: This is an abbreviation for "Read" and "Write". This is displayed in the sidebar so your

--- a/src/ui/pages/drive.rs
+++ b/src/ui/pages/drive.rs
@@ -51,6 +51,8 @@ mod imp {
         pub writable: TemplateChild<adw::ActionRow>,
         #[template_child]
         pub removable: TemplateChild<adw::ActionRow>,
+        #[template_child]
+        pub link: TemplateChild<adw::ActionRow>,
         pub old_stats: RefCell<HashMap<String, usize>>,
         pub last_timestamp: Cell<SystemTime>,
 
@@ -116,6 +118,7 @@ mod imp {
                 capacity: Default::default(),
                 writable: Default::default(),
                 removable: Default::default(),
+                link: Default::default(),
                 uses_progress_bar: Cell::new(true),
                 main_graph_color: glib::Bytes::from_static(&super::ResDrive::MAIN_GRAPH_COLOR),
                 icon: RefCell::new(Drive::default_icon()),
@@ -280,6 +283,7 @@ impl ResDrive {
             removable,
             disk_stats,
             capacity,
+            link,
         } = drive_data;
 
         let time_passed = SystemTime::now()
@@ -419,6 +423,9 @@ impl ResDrive {
             imp.removable.set_subtitle(&i18n("N/A"));
         }
 
+        if let Some(link) = link {
+            imp.link.set_subtitle(&link.to_string());
+        }
         self.set_property(
             "tab_usage_string",
             // Translators: This is an abbreviation for "Read" and "Write". This is displayed in the sidebar so your

--- a/src/ui/pages/gpu.rs
+++ b/src/ui/pages/gpu.rs
@@ -54,6 +54,8 @@ mod imp {
         pub driver_used: TemplateChild<adw::ActionRow>,
         #[template_child]
         pub max_power_cap: TemplateChild<adw::ActionRow>,
+        #[template_child]
+        pub link: TemplateChild<adw::ActionRow>,
 
         #[property(get)]
         uses_progress_bar: Cell<bool>,
@@ -108,6 +110,7 @@ mod imp {
                 pci_slot: Default::default(),
                 driver_used: Default::default(),
                 max_power_cap: Default::default(),
+                link: Default::default(),
                 uses_progress_bar: Cell::new(true),
                 main_graph_color: glib::Bytes::from_static(&super::ResGPU::MAIN_GRAPH_COLOR),
                 icon: RefCell::new(ThemedIcon::new("gpu-symbolic").into()),
@@ -284,6 +287,7 @@ impl ResGPU {
             power_usage,
             power_cap,
             power_cap_max,
+            link,
             nvidia: _,
         } = gpu_data;
 
@@ -424,6 +428,10 @@ impl ResGPU {
             usage_percentage_string.push_str(&temperature_string);
         } else {
             imp.temperature.set_subtitle(&i18n("N/A"));
+        }
+
+        if let Some(link) = link {
+            imp.link.set_subtitle(&link.to_string());
         }
 
         self.set_property("tab_usage_string", &usage_percentage_string);

--- a/src/ui/pages/gpu.rs
+++ b/src/ui/pages/gpu.rs
@@ -432,6 +432,8 @@ impl ResGPU {
 
         if let Some(link) = link {
             imp.link.set_subtitle(&link.to_string());
+        } else {
+            imp.link.set_subtitle(&i18n("N/A"));
         }
 
         self.set_property("tab_usage_string", &usage_percentage_string);

--- a/src/utils/drive.rs
+++ b/src/utils/drive.rs
@@ -42,6 +42,7 @@ impl DriveData {
         let disk_stats = inner.sys_stats().unwrap_or_default();
         let capacity = inner.capacity();
         let link = inner.link();
+
         let drive_data = Self {
             inner,
             is_virtual,
@@ -305,6 +306,12 @@ impl Drive {
             .context("unable to parse model sysfs file")
     }
 
+    /// Returns, whether the Link info of the drive
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if the are errors during
+    /// reading or parsing, or if the drive link type is not supported
     pub fn link(&self) -> Result<Link> {
         Link::for_drive(self)
     }

--- a/src/utils/drive.rs
+++ b/src/utils/drive.rs
@@ -26,7 +26,7 @@ pub struct DriveData {
     pub removable: Result<bool>,
     pub disk_stats: HashMap<String, usize>,
     pub capacity: Result<u64>,
-    pub link: Option<Link>,
+    pub link: Result<Link>,
 }
 
 impl DriveData {
@@ -305,7 +305,7 @@ impl Drive {
             .context("unable to parse model sysfs file")
     }
 
-    pub fn link(&self) -> Option<Link> {
+    pub fn link(&self) -> Result<Link> {
         Link::for_drive(self)
     }
     /// Returns the World-Wide Identification of the drive

--- a/src/utils/drive.rs
+++ b/src/utils/drive.rs
@@ -8,9 +8,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::i18n::{i18n, i18n_f};
-
 use super::units::convert_storage;
+use crate::i18n::{i18n, i18n_f};
+use crate::utils::link::Link;
 
 const PATH_SYSFS: &str = "/sys/block";
 
@@ -26,6 +26,7 @@ pub struct DriveData {
     pub removable: Result<bool>,
     pub disk_stats: HashMap<String, usize>,
     pub capacity: Result<u64>,
+    pub link: Option<Link>,
 }
 
 impl DriveData {
@@ -40,7 +41,7 @@ impl DriveData {
         let removable = inner.removable();
         let disk_stats = inner.sys_stats().unwrap_or_default();
         let capacity = inner.capacity();
-
+        let link = inner.link();
         let drive_data = Self {
             inner,
             is_virtual,
@@ -48,6 +49,7 @@ impl DriveData {
             removable,
             disk_stats,
             capacity,
+            link,
         };
 
         trace!(
@@ -303,6 +305,9 @@ impl Drive {
             .context("unable to parse model sysfs file")
     }
 
+    pub fn link(&self) -> Option<Link> {
+        Link::for_drive(self)
+    }
     /// Returns the World-Wide Identification of the drive
     ///
     /// # Errors

--- a/src/utils/drive.rs
+++ b/src/utils/drive.rs
@@ -306,11 +306,11 @@ impl Drive {
             .context("unable to parse model sysfs file")
     }
 
-    /// Returns, whether the Link info of the drive
+    /// Returns the Link info of the drive
     ///
     /// # Errors
     ///
-    /// Will return `Err` if the are errors during
+    /// Will return `Err` if there are errors during
     /// reading or parsing, or if the drive link type is not supported
     pub fn link(&self) -> Result<Link> {
         Link::for_drive(self)

--- a/src/utils/gpu/mod.rs
+++ b/src/utils/gpu/mod.rs
@@ -83,7 +83,7 @@ impl GpuData {
         let power_cap = gpu.power_cap().ok();
         let power_cap_max = gpu.power_cap_max().ok();
 
-        let link = gpu.link();
+        let link = gpu.link().ok();
 
         let nvidia = matches!(gpu, Gpu::Nvidia(_));
 
@@ -531,7 +531,7 @@ impl Gpu {
         }
     }
 
-    pub fn link(&self) -> Option<Link> {
+    pub fn link(&self) -> Result<Link> {
         Link::for_gpu(self)
     }
 }

--- a/src/utils/gpu/mod.rs
+++ b/src/utils/gpu/mod.rs
@@ -15,14 +15,13 @@ use std::{
     str::FromStr,
 };
 
-use glob::glob;
-
 use self::{amd::AmdGpu, intel::IntelGpu, nvidia::NvidiaGpu, other::OtherGpu};
-use crate::utils::link::Link;
+use crate::utils::link::{Link, PcieLink};
 use crate::{
     i18n::i18n,
     utils::{pci::Device, read_uevent},
 };
+use glob::glob;
 
 use super::pci::Vendor;
 
@@ -532,6 +531,11 @@ impl Gpu {
     }
 
     pub fn link(&self) -> Result<Link> {
-        Link::for_gpu(self)
+        if let GpuIdentifier::PciSlot(pci_address) = self.gpu_identifier() {
+            let pcie_link = PcieLink::new(&pci_address.to_string())?;
+            Ok(Link::Pcie(pcie_link))
+        } else {
+            bail!("Could not retrieve PciSlot from Gpu");
+        }
     }
 }

--- a/src/utils/gpu/mod.rs
+++ b/src/utils/gpu/mod.rs
@@ -17,12 +17,12 @@ use std::{
 
 use glob::glob;
 
+use self::{amd::AmdGpu, intel::IntelGpu, nvidia::NvidiaGpu, other::OtherGpu};
+use crate::utils::link::Link;
 use crate::{
     i18n::i18n,
     utils::{pci::Device, read_uevent},
 };
-
-use self::{amd::AmdGpu, intel::IntelGpu, nvidia::NvidiaGpu, other::OtherGpu};
 
 use super::pci::Vendor;
 
@@ -54,6 +54,8 @@ pub struct GpuData {
     pub power_cap: Option<f64>,
     pub power_cap_max: Option<f64>,
 
+    pub link: Option<Link>,
+
     pub nvidia: bool,
 }
 
@@ -81,6 +83,8 @@ impl GpuData {
         let power_cap = gpu.power_cap().ok();
         let power_cap_max = gpu.power_cap_max().ok();
 
+        let link = gpu.link();
+
         let nvidia = matches!(gpu, Gpu::Nvidia(_));
 
         let gpu_data = Self {
@@ -96,6 +100,7 @@ impl GpuData {
             power_usage,
             power_cap,
             power_cap_max,
+            link,
             nvidia,
         };
 
@@ -524,5 +529,9 @@ impl Gpu {
             Gpu::V3d(gpu) => gpu.power_cap_max(),
             Gpu::Other(gpu) => gpu.power_cap_max(),
         }
+    }
+
+    pub fn link(&self) -> Option<Link> {
+        Link::for_gpu(self)
     }
 }

--- a/src/utils/gpu/mod.rs
+++ b/src/utils/gpu/mod.rs
@@ -531,8 +531,8 @@ impl Gpu {
     }
 
     pub fn link(&self) -> Result<Link> {
-        if let GpuIdentifier::PciSlot(pci_address) = self.gpu_identifier() {
-            let pcie_link = PcieLink::new(&pci_address.to_string())?;
+        if let GpuIdentifier::PciSlot(pci_slot) = self.gpu_identifier() {
+            let pcie_link = PcieLink::from_pci_slot(pci_slot)?;
             Ok(Link::Pcie(pcie_link))
         } else {
             bail!("Could not retrieve PciSlot from Gpu");

--- a/src/utils/link.rs
+++ b/src/utils/link.rs
@@ -1,5 +1,6 @@
 use crate::i18n::i18n;
 use anyhow::{anyhow, bail, Context, Error, Result};
+use process_data::pci_slot::PciSlot;
 use std::fmt::{Display, Formatter};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -34,13 +35,13 @@ pub enum PcieSpeed {
 }
 
 impl PcieLink {
-    pub fn new(pcie_address: &str) -> Result<PcieLink> {
-        let pcie_dir = format!("/sys/bus/pci/devices/{pcie_address}/");
+    pub fn from_pci_slot(pci_slot: PciSlot) -> Result<PcieLink> {
+        let pcie_dir = format!("/sys/bus/pci/devices/{pci_slot}/");
         let pcie_folder = Path::new(pcie_dir.as_str());
         if pcie_folder.exists() {
             return Self::read_pcie_link_data(&pcie_folder.to_path_buf());
         }
-        bail!("Could not find PCIe address entry for {pcie_address}");
+        bail!("Could not find PCIe address entry for {pci_slot}");
     }
 
     fn read_pcie_link_data(path: &PathBuf) -> Result<Self> {

--- a/src/utils/link.rs
+++ b/src/utils/link.rs
@@ -32,36 +32,35 @@ pub enum PcieSpeed {
     Pcie30,
     Pcie40,
     Pcie50,
+    Pcie60,
     #[default]
     Unknown,
 }
 impl Link {
-    pub fn for_drive(drive: &Drive) -> Option<Self> {
+    pub fn for_drive(drive: &Drive) -> Result<Self> {
         //For now only PCIe, later SATA
-        if let Some(pcie_link) = PcieLink::for_drive(drive) {
-            Some(Link::Pcie(pcie_link))
-        } else {
-            Some(Link::Unknown)
+        match PcieLink::for_drive(drive) {
+            Ok(link) => Ok(Link::Pcie(link)),
+            Err(e) => Err(e),
         }
     }
 
-    pub fn for_gpu(gpu: &Gpu) -> Option<Self> {
-        if let Some(pcie_link) = PcieLink::for_gpu(gpu) {
-            Some(Link::Pcie(pcie_link))
-        } else {
-            Some(Link::Unknown)
+    pub fn for_gpu(gpu: &Gpu) -> Result<Self> {
+        match PcieLink::for_gpu(gpu) {
+            Ok(link) => Ok(Link::Pcie(link)),
+            Err(e) => Err(e),
         }
     }
 }
 impl PcieLink {
-    pub fn for_drive(drive: &Drive) -> Option<Self> {
+    pub fn for_drive(drive: &Drive) -> Result<Self> {
         match drive.drive_type {
-            DriveType::Nvme => Self::for_nvme(&drive.sysfs_path).ok(),
-            _ => None,
+            DriveType::Nvme => Self::for_nvme(&drive.sysfs_path),
+            _ => Err(anyhow!("Unsupported drive type")),
         }
     }
 
-    pub fn for_gpu(gpu: &Gpu) -> Option<Self> {
+    pub fn for_gpu(gpu: &Gpu) -> Result<Self> {
         let drm_path = match gpu {
             Gpu::Amd(data) => data.sysfs_path(),
             Gpu::Intel(data) => data.sysfs_path(),
@@ -70,7 +69,7 @@ impl PcieLink {
             Gpu::Other(data) => data.sysfs_path(),
         };
         let device_path = drm_path.join("device");
-        Self::read_pcie_link_data(&device_path.to_path_buf()).ok()
+        Self::read_pcie_link_data(&device_path.to_path_buf())
     }
     fn for_nvme(path: &PathBuf) -> Result<Self> {
         let address_path = path.join("device").join("address");
@@ -152,7 +151,7 @@ impl Display for PcieLink {
 
 impl Display for PcieLinkData {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} {}x", self.speed, self.width)
+        write!(f, "{} x{}", self.speed, self.width)
     }
 }
 
@@ -167,6 +166,7 @@ impl Display for PcieSpeed {
                 PcieSpeed::Pcie30 => "PCIe 3.0".to_string(),
                 PcieSpeed::Pcie40 => "PCIe 4.0".to_string(),
                 PcieSpeed::Pcie50 => "PCIe 5.0".to_string(),
+                PcieSpeed::Pcie60 => "PCIe 6.0".to_string(),
                 PcieSpeed::Unknown => i18n("N/A"),
             }
         )
@@ -182,6 +182,7 @@ impl FromStr for PcieSpeed {
             "8.0 GT/s PCIe" => Ok(PcieSpeed::Pcie30),
             "16.0 GT/s PCIe" => Ok(PcieSpeed::Pcie40),
             "32.0 GT/s PCIe" => Ok(PcieSpeed::Pcie50),
+            "64.0 GT/s PCIe" => Ok(PcieSpeed::Pcie60),
             _ => Err(Error::msg("Could not parse PCIe speed")),
         }
     }
@@ -197,5 +198,175 @@ impl Display for Link {
                 Link::Unknown => i18n("N/A"),
             }
         )
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::utils::link::{PcieLink, PcieLinkData, PcieSpeed};
+    use anyhow::anyhow;
+    use std::collections::HashMap;
+    use std::str::FromStr;
+
+    #[test]
+    fn parse_pcie_link_speeds() {
+        let map = HashMap::from([
+            ("2.5 GT/s PCIe", PcieSpeed::Pcie10),
+            ("5.0 GT/s PCIe", PcieSpeed::Pcie20),
+            ("8.0 GT/s PCIe", PcieSpeed::Pcie30),
+            ("16.0 GT/s PCIe", PcieSpeed::Pcie40),
+            ("32.0 GT/s PCIe", PcieSpeed::Pcie50),
+            ("64.0 GT/s PCIe", PcieSpeed::Pcie60),
+        ]);
+
+        for input in map.keys() {
+            let result = PcieSpeed::from_str(input);
+            assert!(result.is_ok(), "Could not parse PCIe speed for '{}'", input);
+            let expected = map[input];
+            pretty_assertions::assert_eq!(expected, result.unwrap());
+        }
+    }
+
+    #[test]
+    fn display_pcie_link_speeds() {
+        let map = HashMap::from([
+            (PcieSpeed::Pcie10, "PCIe 1.0"),
+            (PcieSpeed::Pcie20, "PCIe 2.0"),
+            (PcieSpeed::Pcie30, "PCIe 3.0"),
+            (PcieSpeed::Pcie40, "PCIe 4.0"),
+            (PcieSpeed::Pcie50, "PCIe 5.0"),
+            (PcieSpeed::Pcie60, "PCIe 6.0"),
+        ]);
+
+        for input in map.keys() {
+            let result = input.to_string();
+            let expected = map[input];
+            pretty_assertions::assert_str_eq!(expected, result);
+        }
+    }
+
+    #[test]
+    fn display_pcie_link_data() {
+        let map = get_test_pcie_link_data();
+
+        for input in map.keys() {
+            let result = input.to_string();
+            let expected = map[input];
+            pretty_assertions::assert_str_eq!(expected, result);
+        }
+    }
+
+    #[test]
+    fn display_pcie_link_identical_current_max_only_once() {
+        let map = get_test_pcie_link_data();
+
+        for link_data in map.keys() {
+            let input = PcieLink {
+                current: Ok(link_data.clone()),
+                max: Ok(link_data.clone()),
+            };
+            let result = input.to_string();
+            let expected = map[link_data];
+            pretty_assertions::assert_str_eq!(expected, result);
+        }
+    }
+
+    #[test]
+    fn display_pcie_link_no_max() {
+        let map = get_test_pcie_link_data();
+
+        for link_data in map.keys() {
+            let input = PcieLink {
+                current: Ok(link_data.clone()),
+                max: Err(anyhow!("No max")),
+            };
+            let result = input.to_string();
+            let expected = map[link_data];
+            pretty_assertions::assert_str_eq!(expected, result);
+        }
+    }
+
+    #[test]
+    fn display_pcie_link_different_max() {
+        let map = get_test_pcie_link_data();
+
+        for current_data in map.keys() {
+            for max_data in map.keys() {
+                if current_data != max_data {
+                    let input = PcieLink {
+                        current: Ok(current_data.clone()),
+                        max: Ok(max_data.clone()),
+                    };
+                    let result = input.to_string();
+                    let expected =
+                        format!("{} / {}", current_data.to_string(), max_data.to_string());
+                    pretty_assertions::assert_str_eq!(expected, result);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn display_pcie_link_different_max_2() {
+        let input = PcieLink {
+            current: Ok(PcieLinkData {
+                speed: PcieSpeed::Pcie40,
+                width: 8,
+            }),
+            max: Ok(PcieLinkData {
+                speed: PcieSpeed::Pcie50,
+                width: 16,
+            }),
+        };
+        let result = input.to_string();
+        let expected = "PCIe 4.0 x8 / PCIe 5.0 x16";
+        pretty_assertions::assert_str_eq!(expected, result);
+    }
+
+    fn get_test_pcie_link_data() -> HashMap<PcieLinkData, &'static str> {
+        HashMap::from([
+            (
+                PcieLinkData {
+                    speed: PcieSpeed::Pcie10,
+                    width: 2,
+                },
+                "PCIe 1.0 x2",
+            ),
+            (
+                PcieLinkData {
+                    speed: PcieSpeed::Pcie20,
+                    width: 4,
+                },
+                "PCIe 2.0 x4",
+            ),
+            (
+                PcieLinkData {
+                    speed: PcieSpeed::Pcie30,
+                    width: 1,
+                },
+                "PCIe 3.0 x1",
+            ),
+            (
+                PcieLinkData {
+                    speed: PcieSpeed::Pcie40,
+                    width: 8,
+                },
+                "PCIe 4.0 x8",
+            ),
+            (
+                PcieLinkData {
+                    speed: PcieSpeed::Pcie50,
+                    width: 16,
+                },
+                "PCIe 5.0 x16",
+            ),
+            (
+                PcieLinkData {
+                    speed: PcieSpeed::Pcie60,
+                    width: 1,
+                },
+                "PCIe 6.0 x1",
+            ),
+        ])
     }
 }

--- a/src/utils/link.rs
+++ b/src/utils/link.rs
@@ -1,6 +1,8 @@
 use crate::i18n::i18n;
+use crate::utils::drive::{Drive, DriveType};
 use anyhow::Result;
 use std::fmt::{Display, Formatter};
+use std::path::PathBuf;
 
 #[derive(Debug, Default)]
 pub enum Link {
@@ -30,6 +32,19 @@ pub enum PcieSpeed {
     Pcie50,
     #[default]
     Unknown,
+}
+
+impl PcieLink {
+    pub fn from_drive(drive: &Drive) -> Option<Self> {
+        match drive.drive_type {
+            DriveType::Nvme => Self::from_nvme(&drive.sysfs_path),
+            _ => None,
+        }
+    }
+
+    fn from_nvme(path: &PathBuf) -> Option<Self> {
+        None
+    }
 }
 
 impl Display for PcieLink {

--- a/src/utils/link.rs
+++ b/src/utils/link.rs
@@ -1,0 +1,76 @@
+use crate::i18n::i18n;
+use anyhow::Result;
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, Default)]
+pub enum Link {
+    Pcie(PcieLink),
+    #[default]
+    Unknown,
+}
+
+#[derive(Debug)]
+pub struct PcieLink {
+    pub current: Result<PcieLinkData>,
+    pub max: Result<PcieLinkData>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct PcieLinkData {
+    pub speed: PcieSpeed,
+    pub width: usize,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum PcieSpeed {
+    Pcie10,
+    Pcie20,
+    Pcie30,
+    Pcie40,
+    Pcie50,
+    #[default]
+    Unknown,
+}
+
+impl Display for PcieLink {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if let Ok(current) = self.current {
+            let different_max = {
+                if let Ok(max) = self.max {
+                    current == max
+                } else {
+                    false
+                }
+            };
+            if different_max {
+                write!(f, "{} / {}", current, self.max.as_ref().unwrap())
+            } else {
+                write!(f, "{}", current)
+            }
+        } else {
+            write!(f, "{}", i18n("N/A"))
+        }
+    }
+}
+
+impl Display for PcieLinkData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} {}x", self.speed, self.width)
+    }
+}
+impl Display for PcieSpeed {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                PcieSpeed::Pcie10 => "PCIE 1.0".to_string(),
+                PcieSpeed::Pcie20 => "PCIE 2.0".to_string(),
+                PcieSpeed::Pcie30 => "PCIE 3.0".to_string(),
+                PcieSpeed::Pcie40 => "PCIE 4.0".to_string(),
+                PcieSpeed::Pcie50 => "PCIE 5.0".to_string(),
+                PcieSpeed::Unknown => i18n("N/A"),
+            }
+        )
+    }
+}

--- a/src/utils/link.rs
+++ b/src/utils/link.rs
@@ -173,6 +173,7 @@ impl Display for PcieSpeed {
 impl FromStr for PcieSpeed {
     type Err = Error;
 
+    /// https://en.wikipedia.org/wiki/PCI_Express#Comparison_table
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s {
             "2.5 GT/s PCIe" => Ok(PcieSpeed::Pcie10),

--- a/src/utils/link.rs
+++ b/src/utils/link.rs
@@ -1,8 +1,9 @@
 use crate::i18n::i18n;
 use crate::utils::drive::{Drive, DriveType};
-use anyhow::Result;
+use anyhow::{anyhow, bail, Context, Error, Result};
 use std::fmt::{Display, Formatter};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 #[derive(Debug, Default)]
 pub enum Link {
@@ -33,17 +34,78 @@ pub enum PcieSpeed {
     #[default]
     Unknown,
 }
-
+impl Link {
+    pub fn for_drive(drive: &Drive) -> Option<Self> {
+        //For now only PCIe, later SATA
+        if let Some(pcie_link) = PcieLink::for_drive(drive) {
+            Some(Link::Pcie(pcie_link))
+        } else {
+            Some(Link::Unknown)
+        }
+    }
+}
 impl PcieLink {
-    pub fn from_drive(drive: &Drive) -> Option<Self> {
+    pub fn for_drive(drive: &Drive) -> Option<Self> {
         match drive.drive_type {
-            DriveType::Nvme => Self::from_nvme(&drive.sysfs_path),
+            DriveType::Nvme => Self::for_nvme(&drive.sysfs_path).ok(),
             _ => None,
         }
     }
 
-    fn from_nvme(path: &PathBuf) -> Option<Self> {
-        None
+    fn for_nvme(path: &PathBuf) -> Result<Self> {
+        let address_path = path.join("device").join("address");
+        let address = std::fs::read_to_string(address_path)
+            .map(|x| x.trim().to_string())
+            .context("Failed to read nvme PCIe address");
+        if let Ok(address) = address {
+            Self::read_using_pcie_address(&address)
+        } else {
+            bail!("Could not find PCIe address in sysfs for nvme")
+        }
+    }
+
+    fn read_using_pcie_address(pcie_address: &str) -> Result<Self> {
+        let pcie_dir = format!("/sys/bus/pci/devices/{pcie_address}/");
+        let pcie_folder = Path::new(pcie_dir.as_str());
+        if pcie_folder.exists() {
+            return Self::read_pcie_link_data(&pcie_folder.to_path_buf());
+        }
+        bail!("Could not find PCIe speed")
+    }
+
+    fn read_pcie_link_data(path: &PathBuf) -> Result<Self> {
+        let current_pcie_speed_raw = std::fs::read_to_string(path.join("current_link_speed"))
+            .map(|x| x.trim().to_string())
+            .context("Could not read current link speed")?;
+        let current_pcie_width_raw = std::fs::read_to_string(path.join("current_link_width"))
+            .map(|x| x.trim().to_string())
+            .context("Could not read current link width")?;
+
+        //Consider max values as optional
+        let max_pcie_speed_raw = std::fs::read_to_string(path.join("max_link_speed"))
+            .map(|x| x.trim().to_string())
+            .context("Could not read max link speed");
+        let max_pcie_width_raw = std::fs::read_to_string(path.join("max_link_width"))
+            .map(|x| x.trim().to_string())
+            .context("Could not read max link width");
+
+        let current = PcieLinkData::parse(&current_pcie_speed_raw, &current_pcie_width_raw);
+        let max = if let (Ok(speed), Ok(width)) = (max_pcie_speed_raw, max_pcie_width_raw) {
+            PcieLinkData::parse(&speed, &width)
+        } else {
+            Err(anyhow!("Could not parse max PCIe link"))
+        };
+        Ok(PcieLink { current, max })
+    }
+}
+
+impl PcieLinkData {
+    pub fn parse(speed_raw: &str, width_raw: &str) -> Result<Self> {
+        let speed = PcieSpeed::from_str(speed_raw)?;
+        let width = width_raw
+            .parse::<usize>()
+            .context("Could not parse PCIe width")?;
+        Ok(PcieLinkData { speed, width })
     }
 }
 
@@ -52,7 +114,7 @@ impl Display for PcieLink {
         if let Ok(current) = self.current {
             let different_max = {
                 if let Ok(max) = self.max {
-                    current == max
+                    current != max
                 } else {
                     false
                 }
@@ -73,18 +135,46 @@ impl Display for PcieLinkData {
         write!(f, "{} {}x", self.speed, self.width)
     }
 }
+
 impl Display for PcieSpeed {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
             "{}",
             match self {
-                PcieSpeed::Pcie10 => "PCIE 1.0".to_string(),
-                PcieSpeed::Pcie20 => "PCIE 2.0".to_string(),
-                PcieSpeed::Pcie30 => "PCIE 3.0".to_string(),
-                PcieSpeed::Pcie40 => "PCIE 4.0".to_string(),
-                PcieSpeed::Pcie50 => "PCIE 5.0".to_string(),
+                PcieSpeed::Pcie10 => "PCIe 1.0".to_string(),
+                PcieSpeed::Pcie20 => "PCIe 2.0".to_string(),
+                PcieSpeed::Pcie30 => "PCIe 3.0".to_string(),
+                PcieSpeed::Pcie40 => "PCIe 4.0".to_string(),
+                PcieSpeed::Pcie50 => "PCIe 5.0".to_string(),
                 PcieSpeed::Unknown => i18n("N/A"),
+            }
+        )
+    }
+}
+impl FromStr for PcieSpeed {
+    type Err = Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "2.5 GT/s PCIe" => Ok(PcieSpeed::Pcie10),
+            "5.0 GT/s PCIe" => Ok(PcieSpeed::Pcie20),
+            "8.0 GT/s PCIe" => Ok(PcieSpeed::Pcie30),
+            "16.0 GT/s PCIe" => Ok(PcieSpeed::Pcie40),
+            "32.0 GT/s PCIe" => Ok(PcieSpeed::Pcie50),
+            _ => Err(Error::msg("Could not parse PCIe speed")),
+        }
+    }
+}
+
+impl Display for Link {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Link::Pcie(data) => data.to_string(),
+                Link::Unknown => i18n("N/A"),
             }
         )
     }

--- a/src/utils/link.rs
+++ b/src/utils/link.rs
@@ -102,7 +102,7 @@ impl Display for PcieLink {
 
 impl Display for PcieLinkData {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} x{}", self.speed, self.width)
+        write!(f, "{} ×{}", self.speed, self.width)
     }
 }
 
@@ -290,7 +290,7 @@ mod test {
             }),
         };
         let result = input.to_string();
-        let expected = "PCIe 4.0 x8 / PCIe 5.0 x16";
+        let expected = "PCIe 4.0 ×8 / PCIe 5.0 ×16";
         pretty_assertions::assert_str_eq!(expected, result);
     }
 
@@ -301,42 +301,42 @@ mod test {
                     speed: PcieSpeed::Pcie10,
                     width: 2,
                 },
-                "PCIe 1.0 x2",
+                "PCIe 1.0 ×2",
             ),
             (
                 PcieLinkData {
                     speed: PcieSpeed::Pcie20,
                     width: 4,
                 },
-                "PCIe 2.0 x4",
+                "PCIe 2.0 ×4",
             ),
             (
                 PcieLinkData {
                     speed: PcieSpeed::Pcie30,
                     width: 1,
                 },
-                "PCIe 3.0 x1",
+                "PCIe 3.0 ×1",
             ),
             (
                 PcieLinkData {
                     speed: PcieSpeed::Pcie40,
                     width: 8,
                 },
-                "PCIe 4.0 x8",
+                "PCIe 4.0 ×8",
             ),
             (
                 PcieLinkData {
                     speed: PcieSpeed::Pcie50,
                     width: 16,
                 },
-                "PCIe 5.0 x16",
+                "PCIe 5.0 ×16",
             ),
             (
                 PcieLinkData {
                     speed: PcieSpeed::Pcie60,
                     width: 1,
                 },
-                "PCIe 6.0 x1",
+                "PCIe 6.0 ×1",
             ),
         ])
     }

--- a/src/utils/link.rs
+++ b/src/utils/link.rs
@@ -270,6 +270,12 @@ mod test {
     }
 
     #[test]
+    fn parse_pcie_link_data_invalid_input() {
+        let result = PcieLinkData::parse("random", "noise");
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn display_pcie_link_identical_current_max_only_once() {
         let map = get_test_pcie_link_data();
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -11,7 +11,7 @@ pub mod battery;
 pub mod cpu;
 pub mod drive;
 pub mod gpu;
-mod link;
+pub mod link;
 pub mod memory;
 pub mod network;
 pub mod npu;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -11,6 +11,7 @@ pub mod battery;
 pub mod cpu;
 pub mod drive;
 pub mod gpu;
+mod link;
 pub mod memory;
 pub mod network;
 pub mod npu;


### PR DESCRIPTION
I am a big fan of HWInfo64 on Windows. Something I never find easy on Linux is to check if your NVME drive or GPU is running at full PCIe speed. The information is there, but it's quite obfuscated when using for example `lspci -vv`.

This PR adds displaying the PCIe link for NVME drives and GPUs. When the max link is different then the current state, it also displays that. It defaults to only showing the current link info when max is identical, to minimize clutter.

I have added a bunch of tests as well. In the future I hope to also add SATA link speed support. But first let's see if you like it :)