### PR TITLE
SATA link speeds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,6 +1187,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "path-dedot"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1344,6 +1353,7 @@ dependencies = [
  "num_cpus",
  "nvml-wrapper",
  "paste",
+ "path-dedot",
  "plotters",
  "plotters-cairo",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ nix = { version = "0.29.0", default-features = false, features = [
 num_cpus = "1.16.0"
 nvml-wrapper = "0.10.0"
 paste = "1.0.15"
+path-dedot = "3.1.1"
 plotters = { version = "0.3.7", default-features = false, features = [
     "area_series",
 ] }

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -354,12 +354,9 @@ impl MainWindow {
             #[strong(rename_to = this)]
             self,
             move |_, key, _, _| {
-                match key {
-                    gdk::Key::Control_L => {
-                        debug!("Ctrl is being held, halting apps and processes updates");
-                        this.imp().pause_updates.set(true);
-                    }
-                    _ => (),
+                if key == gdk::Key::Control_L {
+                    debug!("Ctrl is being held, halting apps and processes updates");
+                    this.imp().pause_updates.set(true);
                 };
                 glib::Propagation::Proceed
             }
@@ -368,12 +365,9 @@ impl MainWindow {
             #[weak]
             imp,
             move |_, key, _, _| {
-                match key {
-                    gdk::Key::Control_L => {
-                        debug!("Ctrl has been released, continuing apps and processes updates");
-                        imp.pause_updates.set(false);
-                    }
-                    _ => (),
+                if key == gdk::Key::Control_L {
+                    debug!("Ctrl has been released, continuing apps and processes updates");
+                    imp.pause_updates.set(false);
                 };
             }
         ));

--- a/src/utils/cpu.rs
+++ b/src/utils/cpu.rs
@@ -295,7 +295,7 @@ fn parse_proc_stat<S: AsRef<str>>(stat: S) -> Vec<Result<(u64, u64)>> {
         .lines()
         .skip(1)
         .filter(|line| line.starts_with("cpu"))
-        .map(|line| parse_proc_stat_line(line))
+        .map(parse_proc_stat_line)
         .collect()
 }
 

--- a/src/utils/drive.rs
+++ b/src/utils/drive.rs
@@ -357,6 +357,7 @@ impl Drive {
         }
         Err(anyhow!("No PCI slot detected"))
     }
+
     fn ata_slot(&self) -> Result<AtaSlot> {
         let symlink = std::fs::read_link(&self.sysfs_path)
             .context("Could not read sysfs_path as symlink")?
@@ -369,7 +370,10 @@ impl Drive {
         let ata_sub_path_match = ata_regex
             .captures(&symlink)
             .context("No ata match found, probably no ata device")?;
-        let ata_sub_path = ata_sub_path_match.get(1).context("TODO")?.as_str();
+        let ata_sub_path = ata_sub_path_match
+            .get(1)
+            .context("No ata match found, probably no ata device")?
+            .as_str();
 
         let ata_device = ata_sub_path_match
             .get(2)
@@ -378,8 +382,8 @@ impl Drive {
             .parse::<u8>()?;
 
         let ata_path = Path::new(&self.sysfs_path).join("..").join(&ata_sub_path);
-        let dedotted_path = ata_path.parse_dot()?.clone();
-        let sub_dirs = std::fs::read_dir(dedotted_path).context("Could not read ata path")?;
+        let dot_parsed_path = ata_path.parse_dot()?.clone();
+        let sub_dirs = std::fs::read_dir(dot_parsed_path).context("Could not read ata path")?;
 
         let ata_link_regex =
             Regex::new(r"(^link(\d+))$").context("Could not parse regex for ata link")?;

--- a/src/utils/gpu/mod.rs
+++ b/src/utils/gpu/mod.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 use self::{amd::AmdGpu, intel::IntelGpu, nvidia::NvidiaGpu, other::OtherGpu};
-use crate::utils::link::{Link, PcieLink};
+use crate::utils::link::{Link, LinkData};
 use crate::{
     i18n::i18n,
     utils::{pci::Device, read_uevent},
@@ -532,7 +532,7 @@ impl Gpu {
 
     pub fn link(&self) -> Result<Link> {
         if let GpuIdentifier::PciSlot(pci_slot) = self.gpu_identifier() {
-            let pcie_link = PcieLink::from_pci_slot(pci_slot)?;
+            let pcie_link = LinkData::from_pci_slot(pci_slot)?;
             Ok(Link::Pcie(pcie_link))
         } else {
             bail!("Could not retrieve PciSlot from Gpu");

--- a/src/utils/gpu/mod.rs
+++ b/src/utils/gpu/mod.rs
@@ -532,7 +532,7 @@ impl Gpu {
 
     pub fn link(&self) -> Result<Link> {
         if let GpuIdentifier::PciSlot(pci_slot) = self.gpu_identifier() {
-            let pcie_link = LinkData::from_pci_slot(pci_slot)?;
+            let pcie_link = LinkData::from_pci_slot(&pci_slot)?;
             Ok(Link::Pcie(pcie_link))
         } else {
             bail!("Could not retrieve PciSlot from Gpu");

--- a/src/utils/gpu/mod.rs
+++ b/src/utils/gpu/mod.rs
@@ -29,7 +29,7 @@ pub const VID_AMD: u16 = 0x1002;
 pub const VID_INTEL: u16 = 0x8086;
 pub const VID_NVIDIA: u16 = 0x10DE;
 
-const RE_CARD_ENUMARATOR: Lazy<Regex> = lazy_regex!(r"(\d+)\/?$");
+static RE_CARD_ENUMARATOR: Lazy<Regex> = lazy_regex!(r"(\d+)\/?$");
 
 #[derive(Debug)]
 pub struct GpuData {

--- a/src/utils/link.rs
+++ b/src/utils/link.rs
@@ -1,4 +1,5 @@
 use crate::i18n::i18n;
+use crate::utils::link::SataSpeed::{Sata150, Sata300, Sata600};
 use anyhow::{anyhow, bail, Context, Error, Result};
 use process_data::pci_slot::PciSlot;
 use std::fmt::{Display, Formatter};
@@ -7,17 +8,17 @@ use std::str::FromStr;
 
 #[derive(Debug, Default)]
 pub enum Link {
-    Pcie(PcieLink),
+    Pcie(LinkData<PcieLinkData>),
+    Sata(LinkData<SataSpeed>),
     #[default]
     Unknown,
 }
 
 #[derive(Debug)]
-pub struct PcieLink {
-    pub current: Result<PcieLinkData>,
-    pub max: Result<PcieLinkData>,
+pub struct LinkData<T> {
+    pub current: Result<T>,
+    pub max: Result<T>,
 }
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PcieLinkData {
     pub speed: PcieSpeed,
@@ -33,9 +34,15 @@ pub enum PcieSpeed {
     Pcie50,
     Pcie60,
 }
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SataSpeed {
+    Sata150,
+    Sata300,
+    Sata600,
+}
 
-impl PcieLink {
-    pub fn from_pci_slot(pci_slot: PciSlot) -> Result<PcieLink> {
+impl LinkData<PcieLinkData> {
+    pub fn from_pci_slot(pci_slot: PciSlot) -> Result<Self> {
         let pcie_dir = format!("/sys/bus/pci/devices/{pci_slot}/");
         let pcie_folder = Path::new(pcie_dir.as_str());
         if pcie_folder.exists() {
@@ -66,7 +73,7 @@ impl PcieLink {
         } else {
             Err(anyhow!("Could not parse max PCIe link"))
         };
-        Ok(PcieLink { current, max })
+        Ok(Self { current, max })
     }
 }
 
@@ -80,7 +87,12 @@ impl PcieLinkData {
     }
 }
 
-impl Display for PcieLink {
+impl<T> Display for LinkData<T>
+where
+    T: Display,
+    T: Copy,
+    T: PartialEq,
+{
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         if let Ok(current) = self.current {
             let has_different_max = {
@@ -98,6 +110,29 @@ impl Display for PcieLink {
         } else {
             write!(f, "{}", i18n("N/A"))
         }
+    }
+}
+
+impl LinkData<SataSpeed> {
+    pub fn from_sata_link(sata_link: &str) -> Result<Self> {
+        let ata_link_path = Path::new("/sys/class/ata_link").join(sata_link);
+        if std::fs::exists(&ata_link_path)? {
+            let current_sata_speed_raw = std::fs::read_to_string(ata_link_path.join("sata_spd"))
+                .map(|x| x.trim().to_string())
+                .context("Could not read sata_spd")?;
+            let max_sata_speed_raw = std::fs::read_to_string(ata_link_path.join("sata_spd_max"))
+                .map(|x| x.trim().to_string())
+                .context("Could not read sata_spd_max");
+
+            let current = SataSpeed::from_str(&current_sata_speed_raw);
+            let max = if let Ok(max_sata_speed_raw) = max_sata_speed_raw {
+                SataSpeed::from_str(&max_sata_speed_raw)
+            } else {
+                Err(anyhow::anyhow!("Could not read sata_spd_max"))
+            };
+            return Ok(Self { current, max });
+        }
+        bail!("ata link path not found for '{}'", sata_link);
     }
 }
 
@@ -135,11 +170,37 @@ impl FromStr for PcieSpeed {
             "16.0 GT/s PCIe" => Ok(PcieSpeed::Pcie40),
             "32.0 GT/s PCIe" => Ok(PcieSpeed::Pcie50),
             "64.0 GT/s PCIe" => Ok(PcieSpeed::Pcie60),
-            _ => Err(anyhow!("Could not parse PCIe speed")),
+            _ => Err(anyhow!("Could not parse PCIe speed: '{s}'")),
         }
     }
 }
 
+impl FromStr for SataSpeed {
+    type Err = Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        match s {
+            "1.5 Gbps" => Ok(Sata150),
+            "3.0 Gbps" => Ok(Sata300),
+            "6.0 Gbps" => Ok(Sata600),
+            _ => Err(anyhow!("Could not parse SATA speed: '{s}'")),
+        }
+    }
+}
+
+impl Display for SataSpeed {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                Sata150 => "SATA-150",
+                Sata300 => "SATA-300",
+                Sata600 => "SATA-600",
+            }
+        )
+    }
+}
 impl Display for Link {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
@@ -147,6 +208,7 @@ impl Display for Link {
             "{}",
             match self {
                 Link::Pcie(data) => data.to_string(),
+                Link::Sata(data) => data.to_string(),
                 Link::Unknown => i18n("N/A"),
             }
         )
@@ -155,7 +217,7 @@ impl Display for Link {
 
 #[cfg(test)]
 mod test {
-    use crate::utils::link::{PcieLink, PcieLinkData, PcieSpeed};
+    use crate::utils::link::{LinkData, PcieLinkData, PcieSpeed, SataSpeed};
     use anyhow::anyhow;
     use std::collections::HashMap;
     use std::str::FromStr;
@@ -233,7 +295,7 @@ mod test {
         let map = get_test_pcie_link_data();
 
         for link_data in map.keys() {
-            let input = PcieLink {
+            let input = LinkData {
                 current: Ok(link_data.clone()),
                 max: Ok(link_data.clone()),
             };
@@ -248,7 +310,7 @@ mod test {
         let map = get_test_pcie_link_data();
 
         for link_data in map.keys() {
-            let input = PcieLink {
+            let input = LinkData {
                 current: Ok(link_data.clone()),
                 max: Err(anyhow!("No max")),
             };
@@ -265,7 +327,7 @@ mod test {
         for current_data in map.keys() {
             for max_data in map.keys() {
                 if current_data != max_data {
-                    let input = PcieLink {
+                    let input = LinkData {
                         current: Ok(current_data.clone()),
                         max: Ok(max_data.clone()),
                     };
@@ -280,7 +342,7 @@ mod test {
 
     #[test]
     fn display_pcie_link_different_max_2() {
-        let input = PcieLink {
+        let input = LinkData {
             current: Ok(PcieLinkData {
                 speed: PcieSpeed::Pcie40,
                 width: 8,
@@ -340,5 +402,50 @@ mod test {
                 "PCIe 6.0 ×1",
             ),
         ])
+    }
+
+    #[test]
+    fn parse_sata_link_speeds() {
+        let map = HashMap::from([
+            ("1.5 Gbps", SataSpeed::Sata150),
+            ("3.0 Gbps", SataSpeed::Sata300),
+            ("6.0 Gbps", SataSpeed::Sata600),
+        ]);
+
+        for input in map.keys() {
+            let result = SataSpeed::from_str(input);
+            assert!(result.is_ok(), "Could not parse SATA speed for '{}'", input);
+            let expected = map[input];
+            pretty_assertions::assert_eq!(expected, result.unwrap());
+        }
+    }
+
+    #[test]
+    fn parse_sata_link_speeds_failure() {
+        let invalid = vec!["4.0 Gbps", "SOMETHING_ELSE", ""];
+
+        for input in invalid {
+            let result = SataSpeed::from_str(input);
+            assert!(
+                result.is_err(),
+                "Could parse SATA speed for '{}' while we don't expect that",
+                input
+            );
+        }
+    }
+
+    #[test]
+    fn display_sata_link_speeds() {
+        let map = HashMap::from([
+            (SataSpeed::Sata150, "SATA-150"),
+            (SataSpeed::Sata300, "SATA-300"),
+            (SataSpeed::Sata600, "SATA-600"),
+        ]);
+
+        for input in map.keys() {
+            let result = input.to_string();
+            let expected = map[input];
+            pretty_assertions::assert_str_eq!(expected, result);
+        }
     }
 }

--- a/src/utils/link.rs
+++ b/src/utils/link.rs
@@ -182,6 +182,7 @@ impl FromStr for SataSpeed {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s {
+            // https://en.wikipedia.org/wiki/SATA
             "1.5 Gbps" => Ok(Sata150),
             "3.0 Gbps" => Ok(Sata300),
             "6.0 Gbps" => Ok(Sata600),

--- a/src/utils/memory.rs
+++ b/src/utils/memory.rs
@@ -241,7 +241,7 @@ impl MemoryDevice {
                 .and_then(|regex| regex.captures(dmi))
                 .and_then(|captures| captures.get(1))
                 .and_then(|capture| capture.as_str().parse::<usize>().ok())
-                .map_or(true, |int| int != 0);
+                != Some(0);
 
             let speed = if installed {
                 Regex::new(&TEMPLATE_RE_CONFIGURED_SPEED_MTS.replace('%', &i))


### PR DESCRIPTION
Expanded a bit on the PCIe Link code to also support SATA speeds. 

It was quite hard to get the actual `ata_link` property from sysfs. The only way I could find to get the ata device and then link was through reading the actual symlink for a `/sys/class/block/x device` and then finding the  `\ataXX\` path and then the `linkXX` subdir of it. Which is somewhat hacky, but I am also too novice in Rust to make it less verbose. So feel free to suggest some changes there.

I added a dependency, which seemed lightweight. It is used to be able to navigate to a joined Path with `../../` from the symlink in it.