### PR TITLE
Cleanup GPU and NPU utility code

### DIFF
--- a/build-aux/net.nokyan.Resources.Devel.json
+++ b/build-aux/net.nokyan.Resources.Devel.json
@@ -66,8 +66,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://git.savannah.nongnu.org/cgit/dmidecode.git/snapshot/dmidecode-3-6.tar.gz",
-                    "sha256": "fe25e4fe567dedf213c5fed0978cb684613ad599d9a50d710476147f58cdb2c1"
+                    "url": "https://download-mirror.savannah.gnu.org/releases/dmidecode/dmidecode-3.6.tar.xz",
+                    "sha256": "e40c65f3ec3dafe31ad8349a4ef1a97122d38f65004ed66575e1a8d575dd8bae"
                 }
             ]
         },

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -271,7 +271,7 @@ impl MainWindow {
             *imp.apps_context.borrow_mut() = AppsContext::new(
                 gpus.iter()
                     .filter(|gpu| gpu.combined_media_engine().unwrap_or_default())
-                    .map(Gpu::gpu_identifier)
+                    .map(|gpu| gpu.gpu_identifier())
                     .collect(),
             );
             imp.apps.init(imp.sender.clone());

--- a/src/utils/gpu/intel.rs
+++ b/src/utils/gpu/intel.rs
@@ -1,9 +1,9 @@
 use anyhow::{Result, bail};
 use process_data::GpuIdentifier;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use crate::utils::pci::Device;
+use crate::utils::{pci::Device, read_sysfs};
 
 use super::GpuImpl;
 
@@ -44,16 +44,16 @@ impl GpuImpl for IntelGpu {
         self.gpu_identifier
     }
 
-    fn driver(&self) -> String {
-        self.driver.clone()
+    fn driver(&self) -> &str {
+        &self.driver
     }
 
-    fn sysfs_path(&self) -> PathBuf {
-        self.sysfs_path.clone()
+    fn sysfs_path(&self) -> &Path {
+        &self.sysfs_path
     }
 
-    fn first_hwmon(&self) -> Option<PathBuf> {
-        self.first_hwmon_path.clone()
+    fn first_hwmon(&self) -> Option<&Path> {
+        self.first_hwmon_path.as_deref()
     }
 
     fn name(&self) -> Result<String> {
@@ -93,7 +93,8 @@ impl GpuImpl for IntelGpu {
     }
 
     fn core_frequency(&self) -> Result<f64> {
-        Ok(self.read_sysfs_int("gt_cur_freq_mhz")? as f64 * 1_000_000.0)
+        read_sysfs::<isize>(self.sysfs_path().join("gt_cur_freq_mhz"))
+            .map(|freq| freq as f64 * 1_000_000.0)
     }
 
     fn vram_frequency(&self) -> Result<f64> {

--- a/src/utils/gpu/nvidia.rs
+++ b/src/utils/gpu/nvidia.rs
@@ -7,7 +7,10 @@ use nvml_wrapper::{
 };
 use process_data::GpuIdentifier;
 
-use std::{path::PathBuf, sync::LazyLock};
+use std::{
+    path::{Path, PathBuf},
+    sync::LazyLock,
+};
 
 static NVML: LazyLock<Result<Nvml, NvmlError>> = LazyLock::new(|| {
     let nvml = Nvml::init();
@@ -80,16 +83,16 @@ impl GpuImpl for NvidiaGpu {
         self.gpu_identifier
     }
 
-    fn driver(&self) -> String {
-        self.driver.clone()
+    fn driver(&self) -> &str {
+        &self.driver
     }
 
-    fn sysfs_path(&self) -> PathBuf {
-        self.sysfs_path.clone()
+    fn sysfs_path(&self) -> &Path {
+        &self.sysfs_path
     }
 
-    fn first_hwmon(&self) -> Option<PathBuf> {
-        self.first_hwmon_path.clone()
+    fn first_hwmon(&self) -> Option<&Path> {
+        self.first_hwmon_path.as_deref()
     }
 
     fn name(&self) -> Result<String> {

--- a/src/utils/gpu/other.rs
+++ b/src/utils/gpu/other.rs
@@ -1,7 +1,7 @@
 use anyhow::{Result, bail};
 use process_data::GpuIdentifier;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::utils::pci::Device;
 
@@ -44,16 +44,16 @@ impl GpuImpl for OtherGpu {
         self.gpu_identifier
     }
 
-    fn driver(&self) -> String {
-        self.driver.clone()
+    fn driver(&self) -> &str {
+        &self.driver
     }
 
-    fn sysfs_path(&self) -> PathBuf {
-        self.sysfs_path.clone()
+    fn sysfs_path(&self) -> &Path {
+        &self.sysfs_path
     }
 
-    fn first_hwmon(&self) -> Option<PathBuf> {
-        self.first_hwmon_path.clone()
+    fn first_hwmon(&self) -> Option<&Path> {
+        self.first_hwmon_path.as_deref()
     }
 
     fn name(&self) -> Result<String> {

--- a/src/utils/gpu/v3d.rs
+++ b/src/utils/gpu/v3d.rs
@@ -1,9 +1,9 @@
 use anyhow::{Result, bail};
 use process_data::GpuIdentifier;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use crate::utils::pci::Device;
+use crate::utils::{pci::Device, read_sysfs};
 
 use super::GpuImpl;
 
@@ -44,16 +44,16 @@ impl GpuImpl for V3dGpu {
         self.gpu_identifier
     }
 
-    fn driver(&self) -> String {
-        self.driver.clone()
+    fn driver(&self) -> &str {
+        &self.driver
     }
 
-    fn sysfs_path(&self) -> PathBuf {
-        self.sysfs_path.clone()
+    fn sysfs_path(&self) -> &Path {
+        &self.sysfs_path
     }
 
-    fn first_hwmon(&self) -> Option<PathBuf> {
-        self.first_hwmon_path.clone()
+    fn first_hwmon(&self) -> Option<&Path> {
+        self.first_hwmon_path.as_deref()
     }
 
     fn name(&self) -> Result<String> {
@@ -93,7 +93,8 @@ impl GpuImpl for V3dGpu {
     }
 
     fn core_frequency(&self) -> Result<f64> {
-        Ok(self.read_sysfs_int("gt_cur_freq_mhz")? as f64 * 1_000_000.0)
+        read_sysfs::<isize>(self.sysfs_path().join("gt_cur_freq_mhz"))
+            .map(|freq| freq as f64 * 1_000_000.0)
     }
 
     fn vram_frequency(&self) -> Result<f64> {

--- a/src/utils/npu/other.rs
+++ b/src/utils/npu/other.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use process_data::pci_slot::PciSlot;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::utils::pci::Device;
 
@@ -44,16 +44,16 @@ impl NpuImpl for OtherNpu {
         self.pci_slot
     }
 
-    fn driver(&self) -> String {
-        self.driver.clone()
+    fn driver(&self) -> &str {
+        &self.driver
     }
 
-    fn sysfs_path(&self) -> PathBuf {
-        self.sysfs_path.clone()
+    fn sysfs_path(&self) -> &Path {
+        &self.sysfs_path
     }
 
-    fn first_hwmon(&self) -> Option<PathBuf> {
-        self.first_hwmon_path.clone()
+    fn first_hwmon(&self) -> Option<&Path> {
+        self.first_hwmon_path.as_deref()
     }
 
     fn name(&self) -> Result<String> {


### PR DESCRIPTION
I've seen that you added NPU monitoring capabilities to Resources and wanted to check out the code. I also looked into PR #431. 

I think that the code becomes "simpler" by using dynamic dispatch using `Deref` on the `Gpu` and `Npu` types. This required me to make the `GpuImpl` and `NpuImpl` traits object-safe and I had to move the generic `read_sysfs_int`/`read_sysfs_file`/`read_device_int`/`read_hwmon_int` functions out of the `GpuImpl` and `NpuImpl` traits. I consolidated these in a new `read_sysfs` function in `src/utils/mod.rs`.

I also refactored some code to cut down on some of the `PathBuf` and `String` allocations where not necessary.

While building the code using `flatpak-builder` I ran into timeouts on `dmidecode`. I've changed the download URL from the `git.savannah.nongnu.org/cgit` endpoint to `download-mirror.savannah.gnu.org`, which should be much faster. 