### PR TITLE
Restore power1_input check

### DIFF
--- a/src/utils/gpu/mod.rs
+++ b/src/utils/gpu/mod.rs
@@ -177,6 +177,7 @@ pub trait GpuImpl {
 
     fn hwmon_power_usage(&self) -> Result<f64> {
         read_sysfs::<isize>(self.hwmon_path()?.join("power1_average"))
+            .or_else(|_| read_sysfs::<isize>(self.hwmon_path()?.join("power1_input")))
             .map(|power| power as f64 / 1_000_000.0)
     }
 


### PR DESCRIPTION
Restore the previous behavior of checking power1_input as an alternative for GPUs that don't support power1_average.  

This fallback check was removed in the PR https://github.com/nokyan/resources/pull/479, but i'm guessing this wasn't intentional. For context, this issue was reported by me one year ago here: https://github.com/nokyan/resources/issues/270