### PR TITLE
Fix battery default tab name

### DIFF
--- a/src/ui/pages/battery.rs
+++ b/src/ui/pages/battery.rs
@@ -99,7 +99,7 @@ mod imp {
                 main_graph_color: glib::Bytes::from_static(&super::ResBattery::MAIN_GRAPH_COLOR),
                 icon: RefCell::new(ThemedIcon::new("battery-symbolic").into()),
                 usage: Default::default(),
-                tab_name: Cell::new(glib::GString::from(i18n("Drive"))),
+                tab_name: Cell::new(glib::GString::from(i18n("Battery"))),
                 tab_detail_string: Cell::new(glib::GString::new()),
                 tab_id: Cell::new(glib::GString::new()),
                 tab_usage_string: Cell::new(glib::GString::new()),


### PR DESCRIPTION
Sloppy copy and paste caused Battery tabs to be called "Drive" per default