### PR TITLE
Fix amdxdna collection and aggregation

### DIFF
--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -591,6 +591,18 @@ impl MainWindow {
                 .unwrap_or_default()
         };
 
+        for npu_data_entry in &mut npu_data {
+            if npu_data_entry.used_memory.is_none() {
+                npu_data_entry.used_memory = Some(
+                    process_data
+                        .iter()
+                        .filter_map(|p| p.npu_usage_stats.get(&npu_data_entry.pci_slot))
+                        .filter_map(|stats| stats.mem())
+                        .sum::<u64>() as usize,
+                );
+            }
+        }
+
         let refresh_data = RefreshData {
             cpu_data,
             mem_data,

--- a/src/utils/npu/amd.rs
+++ b/src/utils/npu/amd.rs
@@ -1,11 +1,51 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use process_data::pci_slot::PciSlot;
 
+use std::fs::File;
+use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 
 use crate::utils::pci::Device;
 
 use super::NpuImpl;
+
+const DRM_IOCTL_BASE: u8 = b'd';
+const DRM_COMMAND_BASE: u8 = 0x40;
+const DRM_AMDXDNA_GET_INFO: u8 = 7;
+const DRM_AMDXDNA_QUERY_CLOCK_METADATA: u32 = 3;
+
+const IOC_WRITE: u32 = 1;
+const IOC_READ: u32 = 2;
+
+const fn ioc(dir: u32, ty: u8, nr: u8, size: usize) -> libc::c_ulong {
+    ((dir << 30) | ((ty as u32) << 8) | (nr as u32) | ((size as u32) << 16)) as libc::c_ulong
+}
+
+const fn iowr<T>(ty: u8, nr: u8) -> libc::c_ulong {
+    ioc(IOC_READ | IOC_WRITE, ty, nr, std::mem::size_of::<T>())
+}
+
+#[repr(C)]
+struct AmdxdnaDrmGetInfo {
+    param: u32,
+    buffer_size: u32,
+    buffer: u64,
+}
+
+#[repr(C)]
+#[derive(Default)]
+struct AmdxdnaDrmQueryClock {
+    name: [u8; 16],
+    freq_mhz: u32,
+    _pad: u32,
+}
+
+#[repr(C)]
+#[derive(Default)]
+struct AmdxdnaDrmQueryClockMetadata {
+    mp_npu_clock: AmdxdnaDrmQueryClock,
+    h_clock: AmdxdnaDrmQueryClock,
+}
 
 #[derive(Debug, Clone, Default)]
 
@@ -32,6 +72,39 @@ impl AmdNpu {
             sysfs_path,
             first_hwmon_path,
         }
+    }
+
+    fn query_clock_metadata(&self) -> Result<(u64, u64)> {
+        let accel_name = self
+            .sysfs_path
+            .file_name()
+            .context("invalid sysfs path")?
+            .to_str()
+            .context("invalid accel name")?;
+        let dev_path = format!("/dev/accel/{accel_name}");
+
+        let file = File::open(&dev_path).context("failed to open accel device")?;
+        let fd = file.as_raw_fd();
+
+        let mut clock_metadata = AmdxdnaDrmQueryClockMetadata::default();
+        let mut get_info = AmdxdnaDrmGetInfo {
+            param: DRM_AMDXDNA_QUERY_CLOCK_METADATA,
+            buffer_size: std::mem::size_of::<AmdxdnaDrmQueryClockMetadata>() as u32,
+            buffer: &mut clock_metadata as *mut _ as u64,
+        };
+
+        let ioctl_cmd =
+            iowr::<AmdxdnaDrmGetInfo>(DRM_IOCTL_BASE, DRM_COMMAND_BASE + DRM_AMDXDNA_GET_INFO);
+
+        let ret = unsafe { libc::ioctl(fd, ioctl_cmd, &mut get_info) };
+        if ret < 0 {
+            anyhow::bail!("ioctl failed: {}", std::io::Error::last_os_error());
+        }
+
+        let h_clock_hz = clock_metadata.h_clock.freq_mhz as u64 * 1_000_000;
+        let mp_npu_clock_hz = clock_metadata.mp_npu_clock.freq_mhz as u64 * 1_000_000;
+
+        Ok((h_clock_hz, mp_npu_clock_hz))
     }
 }
 
@@ -81,11 +154,13 @@ impl NpuImpl for AmdNpu {
     }
 
     fn core_frequency(&self) -> Result<f64> {
-        self.hwmon_core_frequency()
+        self.query_clock_metadata()
+            .map(|(h_clock_hz, _)| h_clock_hz as f64)
     }
 
     fn memory_frequency(&self) -> Result<f64> {
-        self.hwmon_memory_frequency()
+        self.query_clock_metadata()
+            .map(|(_, mp_npu_clock_hz)| mp_npu_clock_hz as f64)
     }
 
     fn power_cap(&self) -> Result<f64> {

--- a/src/utils/process.rs
+++ b/src/utils/process.rs
@@ -41,14 +41,7 @@ static COMPANION_PROCESS: LazyLock<Mutex<(ChildStdin, ChildStdout)>> = LazyLock:
     let child = if *IS_FLATPAK {
         debug!("Spawning resources-processes in Flatpak mode ({proxy_path})");
         Command::new(FLATPAK_SPAWN)
-            .args([
-                &format!(
-                    "--env=RUST_LOG={}",
-                    std::env::var("RUST_LOG=resources").unwrap_or("warn".into())
-                ),
-                "--host",
-                proxy_path.as_str(),
-            ])
+            .args(["--host", proxy_path.as_str()])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())
@@ -57,10 +50,6 @@ static COMPANION_PROCESS: LazyLock<Mutex<(ChildStdin, ChildStdout)>> = LazyLock:
     } else {
         debug!("Spawning resources-processes in native mode ({proxy_path})");
         Command::new(proxy_path)
-            .arg(&format!(
-                "--env=RUST_LOG={}",
-                std::env::var("RUST_LOG=resources").unwrap_or("warn".into())
-            ))
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::inherit())


### PR DESCRIPTION
1. fdinfo collection only accepted DRM devices (major 226), but amdxdna uses the accel subsystem (major 261)
2. Driver name in fdinfo is "amdxdna_accel_driver", not "amdxdna"
3. Memory usage was unavailable because amdxdna doesn't expose it via sysfs, only via per-process fdinfo
4. There is no "--env" parameter in resources-processes

This change was tested against the latest release of amdxdna driver, which is massively different from the driver shipped in Linux kernel. Maybe older driver uses "amdxdna" instead of "amdxdna_accel_driver". However, as new software works only with the new driver, I don't even think it is possible to test something with original driver. More details: https://wiki.gentoo.org/wiki/User:Lockal/AMDXDNA#Kernel

Another note: Temperature, power, and frequency remain N/A as amdxdna does not expose hwmon interface (at least for my Asus ROG Z13 device). Maybe it makes sense to remove these fields from UI.

Part of: https://github.com/nokyan/resources/issues/417