### PR TITLE
Always use decimal base for network speeds if they're set to be shown in bit/s

### DIFF
--- a/src/utils/units.rs
+++ b/src/utils/units.rs
@@ -178,7 +178,10 @@ pub fn convert_speed(bytes_per_second: f64, network: bool) -> String {
         if SETTINGS.network_bits() {
             convert_speed_bits_decimal(bytes_per_second * 8.0)
         } else {
-            convert_speed_decimal(bytes_per_second)
+            match SETTINGS.base() {
+                Base::Decimal => convert_speed_decimal(bytes_per_second * 8.0),
+                Base::Binary => convert_speed_binary(bytes_per_second),
+            }
         }
     } else {
         match SETTINGS.base() {


### PR DESCRIPTION
Resolves #593 