### PR TITLE
Hide NPU utilization and memory graphs if no data

### DIFF
--- a/src/ui/pages/npu.rs
+++ b/src/ui/pages/npu.rs
@@ -206,9 +206,13 @@ impl ResNPU {
             Self::MAIN_GRAPH_COLOR[1],
             Self::MAIN_GRAPH_COLOR[2],
         );
+        // Initially hidden until we have data
+        imp.npu_usage.set_visible(false);
 
         imp.memory_usage.set_title_label(&i18n("Memory Usage"));
         imp.memory_usage.graph().set_graph_color(0x9e, 0x1c, 0xcc);
+        // Initially hidden until we have data
+        imp.memory_usage.set_visible(false);
 
         imp.temperature.set_title_label(&i18n("Temperature"));
         imp.temperature.graph().set_graph_color(0x83, 0x1c, 0xac);
@@ -260,7 +264,7 @@ impl ResNPU {
         imp.npu_usage
             .graph()
             .push_data_point(usage_fraction.unwrap_or(0.0));
-        imp.npu_usage.graph().set_visible(usage_fraction.is_some());
+        imp.npu_usage.set_visible(usage_fraction.is_some());
 
         let memory_subtitle = if let (Some(total_memory), Some(used_memory)) =
             (total_memory, used_memory)
@@ -310,7 +314,7 @@ impl ResNPU {
             i18n("N/A")
         };
 
-        imp.memory_usage.graph().set_visible(used_memory.is_some());
+        imp.memory_usage.set_visible(used_memory.is_some());
 
         imp.memory_usage.set_subtitle(&memory_subtitle);
 

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -723,17 +723,25 @@ impl MainWindow {
             let page = page.content().and_downcast::<ResNPU>().unwrap();
 
             let processes_npu_fraction = apps_context.npu_fraction(npu_data.pci_slot);
-            npu_data.usage_fraction = Some(f64::max(
+            let max_usage = f64::max(
                 npu_data.usage_fraction.unwrap_or(0.0),
                 processes_npu_fraction.into(),
-            ));
+            );
+            // Only set to Some if there's actual activity
+            npu_data.usage_fraction = (max_usage > 0.0).then_some(max_usage);
 
-            if npu_data.total_memory.is_some() {
+            // Only recalculate memory if we have a valid non-zero total memory capacity
+            if npu_data.total_memory.is_some_and(|total| total > 0) {
                 let processes_npu_memory_fraction = apps_context.npu_mem(npu_data.pci_slot);
-                npu_data.used_memory = Some(usize::max(
+                let max_memory = usize::max(
                     npu_data.used_memory.unwrap_or(0),
                     processes_npu_memory_fraction as usize,
-                ));
+                );
+                // Only set to Some if there's actual memory usage
+                npu_data.used_memory = (max_memory > 0).then_some(max_memory);
+            } else {
+                // No valid total memory, so we can't show memory usage meaningfully
+                npu_data.used_memory = None;
             }
 
             page.refresh_page(&npu_data);

--- a/src/utils/npu/mod.rs
+++ b/src/utils/npu/mod.rs
@@ -56,10 +56,10 @@ impl NpuData {
 
         trace!("Gathering NPU data for {pci_slot}…");
 
-        let usage_fraction = npu.usage().ok();
+        let usage_fraction = npu.usage().ok().and_then(|u| (u > 0.0).then_some(u));
 
         let total_memory = npu.total_memory().ok();
-        let used_memory = npu.used_memory().ok();
+        let used_memory = npu.used_memory().ok().and_then(|m| (m > 0).then_some(m));
 
         let clock_speed = npu.core_frequency().ok();
         let vram_speed = npu.memory_frequency().ok();


### PR DESCRIPTION
amdxdna doesn't currently provide an API for this data, the graphs shouldn't be shown.