### PR TITLE
fix(units): show RAM in binary and disk capacity in decimal

### DIFF
--- a/src/ui/pages/drive.rs
+++ b/src/ui/pages/drive.rs
@@ -7,7 +7,7 @@ use log::trace;
 use crate::config::PROFILE;
 use crate::i18n::{i18n, i18n_f};
 use crate::utils::drive::{Drive, DriveData};
-use crate::utils::units::{convert_speed, convert_storage};
+use crate::utils::units::{convert_speed, convert_storage, convert_storage_decimal};
 
 pub const TAB_ID_PREFIX: &str = "drive";
 
@@ -404,7 +404,7 @@ impl ResDrive {
 
         if let Ok(capacity) = capacity {
             imp.capacity
-                .set_subtitle(&convert_storage(capacity as f64, false));
+                .set_subtitle(&convert_storage_decimal(capacity as f64, false));
         } else {
             imp.capacity.set_subtitle(&i18n("N/A"));
         }

--- a/src/ui/pages/memory.rs
+++ b/src/ui/pages/memory.rs
@@ -6,7 +6,7 @@ use crate::config::PROFILE;
 use crate::i18n::{i18n, i18n_f};
 use crate::utils::FiniteOr;
 use crate::utils::memory::{MemoryData, MemoryDevice};
-use crate::utils::units::convert_storage;
+use crate::utils::units::convert_storage_binary;
 
 pub const TAB_ID: &str = "memory";
 
@@ -247,7 +247,7 @@ impl ResMemory {
             "tab_detail_string",
             format!(
                 "{} {}",
-                convert_storage(total_memory, false),
+                convert_storage_binary(total_memory, false),
                 memory_devices
                     .iter()
                     .find(|md| md.installed)
@@ -310,8 +310,8 @@ impl ResMemory {
         let memory_fraction = used_mem as f64 / total_mem as f64;
         let swap_fraction = (used_swap as f64 / total_swap as f64).finite_or_default();
 
-        let formatted_used_mem = convert_storage(used_mem as f64, false);
-        let formatted_total_mem = convert_storage(total_mem as f64, false);
+        let formatted_used_mem = convert_storage_binary(used_mem as f64, false);
+        let formatted_total_mem = convert_storage_binary(total_mem as f64, false);
 
         imp.memory.graph().push_data_point(memory_fraction);
         imp.memory.set_subtitle(&format!(
@@ -334,8 +334,8 @@ impl ResMemory {
             imp.swap.graph().set_visible(true);
             imp.swap.set_subtitle(&format!(
                 "{} / {} · {} %",
-                &convert_storage(used_swap as f64, false),
-                &convert_storage(total_swap as f64, false),
+                &convert_storage_binary(used_swap as f64, false),
+                &convert_storage_binary(total_swap as f64, false),
                 (swap_fraction * 100.0).round()
             ));
             self.set_property(
@@ -364,7 +364,7 @@ impl ResMemory {
             "tab_detail_string",
             format!(
                 "{} {}",
-                convert_storage(total_memory, false),
+                convert_storage_binary(total_memory, false),
                 memory_devices
                     .iter()
                     .find(|md| md.installed)

--- a/src/utils/drive.rs
+++ b/src/utils/drive.rs
@@ -1,4 +1,4 @@
-use super::units::convert_storage;
+use super::units::convert_storage_decimal;
 use crate::i18n::{i18n, i18n_f};
 use crate::utils::link::{Link, LinkData};
 use crate::utils::read_parsed;
@@ -203,7 +203,8 @@ impl Drive {
     }
 
     pub fn display_name(&self) -> String {
-        let capacity_formatted = convert_storage(self.capacity().unwrap_or_default() as f64, true);
+        let capacity_formatted =
+            convert_storage_decimal(self.capacity().unwrap_or_default() as f64, true);
         match self.drive_type {
             DriveType::CdDvdBluray => i18n("CD/DVD/Blu-ray Drive"),
             DriveType::Floppy => i18n("Floppy Drive"),


### PR DESCRIPTION
## Summary
- make memory page values always use binary units (GiB), independent of the global base toggle
- make drive capacity labels/title use decimal units (GB), matching common disk reporting conventions
- scope kept to memory/drive presentation paths tied to #637

## Testing
- Ran: `git diff --check` (no whitespace errors)
- Not run: project test/build commands, because Rust toolchain (`cargo`) is unavailable in this runtime

## Related
Fixes #637