### PR TITLE
Use overlay for usage-labels

### DIFF
--- a/data/resources/ui/widgets/stack_sidebar_item.ui
+++ b/data/resources/ui/widgets/stack_sidebar_item.ui
@@ -9,61 +9,68 @@
     <property name="margin-start">8</property>
     <property name="margin-end">8</property>
     <property name="child">
-      <object class="GtkBox">
-        <property name="orientation">vertical</property>
-        <property name="spacing">4</property>
+      <object class="GtkOverlay">
+        <property name="visible">1</property>
         <child>
           <object class="GtkBox">
-            <property name="orientation">horizontal</property>
-            <property name="spacing">12</property>
+            <property name="orientation">vertical</property>
+            <property name="spacing">4</property>
             <child>
-              <object class="GtkImage" id="image">
-                <property name="pixel-size">16</property>
+              <object class="GtkBox">
+                <property name="orientation">horizontal</property>
+                <property name="spacing">12</property>
+                <child>
+                  <object class="GtkImage" id="image">
+                    <property name="pixel-size">16</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="label">
+                    <property name="xalign">0</property>
+                    <property name="hexpand">1</property>
+                    <property name="ellipsize">end</property>
+                  </object>
+                </child>
               </object>
             </child>
             <child>
-              <object class="GtkLabel" id="label">
+              <object class="GtkLabel" id="detail_label">
                 <property name="xalign">0</property>
                 <property name="hexpand">1</property>
                 <property name="ellipsize">end</property>
+                <style>
+                  <class name="caption"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkProgressBar" id="progress_bar">
+                <style>
+                  <class name="slim"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="ResGraph" id="graph">
+                <style>
+                  <class name="small-graph"/>
+                </style>
+                <property name="overflow">hidden</property>
+                <property name="height-request">80</property>
               </object>
             </child>
           </object>
         </child>
-        <child>
-          <object class="GtkLabel" id="detail_label">
-            <property name="xalign">0</property>
-            <property name="hexpand">1</property>
-            <property name="ellipsize">end</property>
-            <style>
-              <class name="caption"/>
-            </style>
-          </object>
-        </child>
-        <child>
+        <child type="overlay">
           <object class="GtkLabel" id="usage_label">
+            <property name="valign">end</property>
+            <property name="halign">end</property>
             <property name="xalign">0</property>
             <property name="hexpand">1</property>
             <property name="ellipsize">end</property>
             <style>
               <class name="subtitle"/>
             </style>
-          </object>
-        </child>
-        <child>
-          <object class="GtkProgressBar" id="progress_bar">
-            <style>
-              <class name="slim"/>
-            </style>
-          </object>
-        </child>
-        <child>
-          <object class="ResGraph" id="graph">
-            <style>
-              <class name="small-graph"/>
-            </style>
-            <property name="overflow">hidden</property>
-            <property name="height-request">80</property>
           </object>
         </child>
       </object>


### PR DESCRIPTION
To aid you with a quick idea (I hope I got the request right) on https://gitlab.gnome.org/GNOME/Incubator/Submission/-/work_items/20 - how to show usage labels as overlay over the chart, purely UI changes, CSS still needs to be fine-tuned for best visibility. Also removed Running "Apps/Processes" from  as Apps Running Apps: X and Processes: Running Processes: X seemed too heavy/wide, and duplicated.
